### PR TITLE
chore(release): v0.8.0, version workspace, sync projects, amend past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,3 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Features
 
 * theme overrides for Card, CardContent, CardActions ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
-
-
-
-## [0.7.3](https://github.com/prenda-school/prenda-spark/compare/spark-0.7.2...spark-0.7.3) (2021-06-16)
-
-## [0.7.2](https://github.com/prenda-school/prenda-spark/compare/spark-0.7.1...spark-0.7.2) (2021-05-29)
-
-- initial commit for changelog.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 # [0.8.0](https://github.com/prenda-school/prenda-spark/compare/v0.7.3...v0.8.0) (2021-06-22)
 
-
 ### Features
 
-* theme overrides for Card, CardContent, CardActions ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+#### Spark
+
+- **Card:** theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **CardContent:** theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **CardActions:** theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **theme:** custom shadows ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 #### Spark
 
-- **Card:** theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
-- **CardContent:** theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
-- **CardActions:** theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **Card:** initial implementation, theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **CardContent:** initial implementation, theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **CardActions:** initial implementation, theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
 - **theme:** custom shadows ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
-
-

--- a/apps/spark-e2e/CHANGELOG.md
+++ b/apps/spark-e2e/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
+
+# [0.8.0](https://github.com/prenda-school/prenda-spark/compare/v0.7.3...v0.8.0) (2021-06-22)

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -4,14 +4,16 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 # [0.8.0](https://github.com/prenda-school/prenda-spark/compare/v0.7.3...v0.8.0) (2021-06-22)
 
-
 ### Features
 
-* theme overrides for Card, CardContent, CardActions ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
-
-
+- **Card:** initial implementation, theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **CardContent:** initial implementation, theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **CardActions:** initial implementation, theme style overrides ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
+- **theme:** custom shadows ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
 
 ## [0.7.3](https://github.com/prenda-school/prenda-spark/compare/spark-0.7.2...spark-0.7.3) (2021-06-16)
+
+- **Navbar:** initial implementation ([#64](https://github.com/prenda-school/prenda-spark/issues/64)) ([8af41e3](https://github.com/prenda-school/prenda-spark/commit/8af41e35ac52fa59c6bb07f6c618995744f77887))
 
 ## [0.7.2](https://github.com/prenda-school/prenda-spark/compare/spark-0.7.1...spark-0.7.2) (2021-05-29)
 

--- a/libs/spark/package.json
+++ b/libs/spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prenda/spark",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "author": "Prenda",
   "license": "MIT"
 }

--- a/nx.json
+++ b/nx.json
@@ -31,6 +31,9 @@
     "spark-e2e": {
       "tags": [],
       "implicitDependencies": ["spark"]
+    },
+    "workspace": {
+      "tags": []
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1864,6 +1864,85 @@
         }
       }
     },
+    "@angular-devkit/schematics": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-12.0.5.tgz",
+      "integrity": "sha512-iW3XuDHScr3TXuunlEjF5O01zBpwpLgfr1oEny8PvseFGDlHK4Nj8zNIoIn3Yg936aiFO4GJAC/UXsT8g5vKxQ==",
+      "requires": {
+        "@angular-devkit/core": "12.0.5",
+        "ora": "5.4.0",
+        "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "@angular-devkit/core": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.0.5.tgz",
+          "integrity": "sha512-zVSQV+8/vjUjsUKGlj8Kf5LioA6AXJTGI0yhHW9q1dFX4dPpbW63k0R1UoIB2wJ0F/AbYVgpnPGPe9BBm2fvZA==",
+          "requires": {
+            "ajv": "8.2.0",
+            "ajv-formats": "2.0.2",
+            "fast-json-stable-stringify": "2.1.0",
+            "magic-string": "0.25.7",
+            "rxjs": "6.6.7",
+            "source-map": "0.7.3"
+          }
+        },
+        "ajv": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
+          "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "ora": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.0.tgz",
+          "integrity": "sha512-1StwyXQGoU6gdjYkyVcqOLnVlbKj+6yPNNOxJVgpt9t4eksKjiriiHuxktLYkgllwk+D6MbC4ihH84L1udRXPg==",
+          "requires": {
+            "bl": "^4.1.0",
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.5.0",
+            "is-interactive": "^1.0.0",
+            "is-unicode-supported": "^0.1.0",
+            "log-symbols": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "private": true,
   "dependencies": {
     "@angular-devkit/build-angular": "^12.0.3",
+    "@angular-devkit/schematics": "^12.0.5",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/styles": "^4.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prenda-spark",
-  "version": "0.0.0",
+  "version": "0.8.0",
   "license": "MIT",
   "scripts": {
     "nx": "nx",

--- a/workspace.json
+++ b/workspace.json
@@ -127,6 +127,17 @@
           }
         }
       }
+    },
+    "workspace": {
+      "targets": {
+        "version": {
+          "executor": "@jscutlery/semver:version",
+          "options": {
+            "syncVersions": true
+          }
+        }
+      },
+      "root": "."
     }
   }
 }


### PR DESCRIPTION
Closes #65. 

Adds missing tag for `spark-0.7.3` as noted in #72.
    - Amends the missing CHANGELOG entry as well, with suitable scope.

Adds initial workspace tag `v0.7.3` on same commit as `spark-0.7.3` tag

Installs `@jscutlery/semver` for the entire workspace
    - _NOTE:_ Conventional Commits is _not_ enforced as a `commit-msg` hook. Contributors are free to describe commits however they like. It is the responsibility of the maintainers that the squash-and-merge commit abides by Conventional Commits.

Runs release generator to bump workspace and projects, keeping versions synced.
```bash
npx nx run workspace:version --sync-versions true
git push --follow-tags origin <branch-name>
```

Amends CHANGELOG's to improve feature descriptions, scopes.

-----

### Elaborating on Squash & Merge

Here's the commit msg that GitHub suggests on the squash & merge of #71 

```git
Card component (#71)

* feat: lighten MUI shadow in Prenda theme

* chore: change pre- hooks to only lint affected

* feat: add Card with tests and stories

* chore: remove unused imports

* chore: move shadow definition out of theme file

* remove Card components, replace with default styles and props in Mui theme

* make Card examples match Figma examples

* Increase paragraph size to match Figma

Co-authored-by: William Kelley <williamkelley9@gmail.com>

* Increase paragraph size to match Figma

Co-authored-by: William Kelley <williamkelley9@gmail.com>

* Card story: Button -> IconButton, increase title gutter, limit card1 width

Co-authored-by: William Kelley <williamkelley9@gmail.com>
```

Here's what I modified it to: _(note, this wasn't exactly the best choice)_
```git
feat: theme overrides for Card, CardContent, CardActions (#71)

feat: custom theme shadows

chore: lint affected
```

Here's the CHANGELOG entry that generates:
```md
# [0.8.0](https://github.com/prenda-school/prenda-spark/compare/v0.7.3...v0.8.0) (2021-06-22)

### Features

- theme overrides for Card, CardContent, CardActions ([#71](https://github.com/prenda-school/prenda-spark/issues/71)) ([85068ec](https://github.com/prenda-school/prenda-spark/commit/85068ec14bad64c8251d47be482b12d85474dcb8))
```

The CHANGELOG is meh. The plugin only captures the commit subject, not additional messages in the commit body. This makes sense because it abides by the Conventional Commits spec. I should have at least scoped the subject to be `feat(Card): theme overrides, also for CardContent, CardActions`. Then the change entry would have been 
```md
- **Card:** theme overrides, also for CardContent, CardActions ...
```
The scope is a bit nicer for the reader. But the best output required manual amendment of breaking out each scope. 
```md
- **Card:** theme overrides ... 
- **CardContent:** theme overrides ...
- **CardActions:** theme overrides ...
- **theme:** custom shadows ...
```

With the above in mind, the process I'd like to finalize is transforming the GitHub's suggested squash-and-merge commit msg above, to
```git
feat(Card): initial implementation, theme style overrides (#71)

feat(CardContent): initial implementation, theme style overrides (#71)

feat(CardActions): initial implementation, theme style overrides (#71)

feat(theme): custom shadows (#71)

* feat: lighten MUI shadow in Prenda theme

* chore: change pre- hooks to only lint affected

* feat: add Card with tests and stories

* chore: remove unused imports

* chore: move shadow definition out of theme file

* remove Card components, replace with default styles and props in Mui theme

* make Card examples match Figma examples

* Increase paragraph size to match Figma

Co-authored-by: William Kelley <williamkelley9@gmail.com>

* Increase paragraph size to match Figma

Co-authored-by: William Kelley <williamkelley9@gmail.com>

* Card story: Button -> IconButton, increase title gutter, limit card1 width

Co-authored-by: William Kelley <williamkelley9@gmail.com>
```

Essentially, 
1. Keep all the squashed history -- the plugin won't pick it up anyway
2. Expand on what the significant conventional commits should be for the PR
3. Run the versioning command
4. Amend the CHANGELOG(s) to expand on uncaptured merge-commit-message-body-entries