### PR TITLE
chore(workflow): change published to released

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,8 @@
 name: NPM Publish
 on:
   release:
-    types: [published]
+    types: [released]
+  workflow_dispatch:
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The action didn't trigger when I released an existing tag. I'm not sure why, hopefully this change fixes that.
    
I added `workflow_dispatch` so I can manually trigger the action for the existing release