### PR TITLE
feat(SvgIcon): add global styles and props

### DIFF
--- a/libs/spark/src/Checkbox.tsx
+++ b/libs/spark/src/Checkbox.tsx
@@ -111,11 +111,13 @@ function SparkCheckboxIcon(props: {
       })}
     >
       <SparkCheckboxUncheckedIcon
+        color="inherit"
         fontSize={fontSize}
         viewBox="0 0 22 22"
         className="SparkCheckboxIcon-box"
       />
       <SparkCheckboxCheckedIcon
+        color="inherit"
         fontSize={fontSize}
         viewBox="0 0 22 22"
         className="SparkCheckboxIcon-checkmark"

--- a/libs/spark/src/Radio.tsx
+++ b/libs/spark/src/Radio.tsx
@@ -105,11 +105,13 @@ function SparkRadioButtonIcon(props: {
       })}
     >
       <SparkRadioButtonUncheckedIcon
+        color="inherit"
         fontSize={fontSize}
         viewBox="0 0 26 26"
         className="SparkRadioIcon-circle"
       />
       <SparkRadioButtonCheckedIcon
+        color="inherit"
         fontSize={fontSize}
         viewBox="0 0 26 26"
         className="SparkRadioIcon-dot"

--- a/libs/spark/src/SvgIcon.tsx
+++ b/libs/spark/src/SvgIcon.tsx
@@ -1,0 +1,56 @@
+import React, { FC } from 'react';
+import { SvgIcon, SvgIconProps as MuiSvgIconProps } from '@material-ui/core';
+import { colors } from './theme/colors';
+import clsx from 'clsx';
+import { capitalize } from './utils';
+
+export interface SvgIconProps extends MuiSvgIconProps {
+  contrast?: 'high' | 'low';
+}
+
+export const MuiSvgIconPropOverride = {
+  color: 'primary' as const,
+};
+
+export const MuiSvgIconStyleOverrides = {
+  root: {
+    // fontSizeDefault
+    fontSize: '1.5rem', // 24px
+    '&.SparkSvgIcon-contrastHigh': {
+      opacity: 0.72,
+    },
+    '&.SparkSvgIcon-contrastLow': {
+      opacity: 0.72,
+    },
+  },
+  fontSizeSmall: {
+    fontSize: '1rem', // 16px
+  },
+  fontSizeLarge: {
+    fontSize: '2rem', // 32px
+  },
+  colorPrimary: {
+    color: colors.colorsTextIconOnLightHighContrast,
+  },
+  colorSecondary: {
+    color: colors.colorsTextIconOnDarkHighContrast,
+  },
+};
+
+const SparkSvgIcon: FC<SvgIconProps> = ({
+  contrast = 'high',
+  className,
+  ...other
+}) => {
+  return (
+    <SvgIcon
+      className={clsx(
+        className,
+        `SparkSvgIcon-contrast${capitalize(contrast)}`
+      )}
+      {...other}
+    />
+  );
+};
+
+export { SparkSvgIcon as SvgIcon };

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -40,6 +40,8 @@ export {
 export { Radio } from './Radio';
 export type { RadioProps } from './Radio';
 export { SparkThemeProvider } from './SparkThemeProvider';
+export { SvgIcon } from './SvgIcon';
+export type { SvgIconProps } from './SvgIcon';
 export { muiTheme, prendaTheme } from './theme';
 export type { TertiaryColor } from './theme';
 export { Typography } from './Typography';

--- a/libs/spark/src/theme/theme.ts
+++ b/libs/spark/src/theme/theme.ts
@@ -22,6 +22,7 @@ import {
 } from '../Checkbox';
 import { MuiFormControlLabelStyleOverrides } from '../FormControlLabel';
 import { MuiRadioPropOverrides, MuiRadioStyleOverrides } from '../Radio';
+import { MuiSvgIconPropOverride, MuiSvgIconStyleOverrides } from '../SvgIcon';
 
 export type TertiaryColor = {
   1: string;
@@ -135,6 +136,7 @@ export const prendaTheme: ThemeOptions = {
     MuiCheckbox: MuiCheckboxStyleOverrides,
     MuiFormControlLabel: MuiFormControlLabelStyleOverrides,
     MuiRadio: MuiRadioStyleOverrides,
+    MuiSvgIcon: MuiSvgIconStyleOverrides,
   },
   shadows,
   palette: {
@@ -228,6 +230,7 @@ export const prendaTheme: ThemeOptions = {
     MuiCard: MuiCardPropOverrides,
     MuiCheckbox: MuiCheckboxPropOverrides,
     MuiRadio: MuiRadioPropOverrides,
+    MuiSvgIcon: MuiSvgIconPropOverride,
   },
 };
 


### PR DESCRIPTION
part of #75 

This new customization will replace the current `Icon` -- will be removed in another PR (since that's just a custom SvgIcon. I implemented the `contrast` prop by changing the `opacity` CSS property instead of switching to the `...LowContrast` version of the text colors. This was to simplify implementation. From my assessment, with something so simple as icons, it produces the exact same result.

This is also a prerequisite for #73 