### PR TITLE
chore: remove fonts.d.ts

### DIFF
--- a/libs/spark/src/fonts.d.ts
+++ b/libs/spark/src/fonts.d.ts
@@ -1,2 +1,0 @@
-declare module '*.woff';
-declare module '*.woff2';


### PR DESCRIPTION
Was a relic of an old font import attempt, definitely not needed now.