### PR TITLE
refactor(Menu): add utility class for margin top

### DIFF
--- a/libs/spark/src/Dropdown.tsx
+++ b/libs/spark/src/Dropdown.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import {
-  Menu as MuiMenu,
+  Menu,
   MenuProps as MuiMenuProps,
   MenuItemProps as MuiMenuItemProps,
   Divider as MuiDivider,
-  Theme,
 } from '@material-ui/core';
 import { Button, ButtonProps } from './Button';
 import styled from 'styled-components';
@@ -40,12 +39,6 @@ export interface DropdownMenuItemProps
   // Fix mismatch from MUI
   button?: true | undefined;
 }
-
-const StyledMenu = styled(MuiMenu)`
-  ${({ theme }: { theme: Theme }) => `
-    inset: 8px 0 0 0 !important;
-  `}
-`;
 
 const SparkDropdownDivider = styled(MuiDivider)`
   height: 2px;
@@ -96,11 +89,11 @@ const SparkDropdownButton: React.FC<DropdownButtonProps> = (props) => {
 };
 
 const SparkDropdownMenu = React.forwardRef<HTMLUListElement, DropdownMenuProps>(
-  (props, ref) => {
+  ({ classes, ...other }, ref) => {
     const { id, anchorEl, handleClose } = React.useContext(Context);
 
     return (
-      <StyledMenu
+      <Menu
         id={id}
         getContentAnchorEl={null}
         anchorEl={anchorEl}
@@ -116,7 +109,8 @@ const SparkDropdownMenu = React.forwardRef<HTMLUListElement, DropdownMenuProps>(
           horizontal: 'right',
         }}
         ref={ref}
-        {...props}
+        PaperProps={{ className: 'SparkMenu-paperOffsetTop' }}
+        {...other}
       />
     );
   }

--- a/libs/spark/src/Menu.ts
+++ b/libs/spark/src/Menu.ts
@@ -1,4 +1,5 @@
 import { palette } from './styles/palette';
+
 export const MuiMenuDefaultProps = {
   elevation: 3,
 };
@@ -6,6 +7,9 @@ export const MuiMenuDefaultProps = {
 export const MuiMenuStyleOverrides = {
   paper: {
     borderRadius: 8,
+    '&.SparkMenu-paperOffsetTop': {
+      marginTop: 8,
+    },
   },
   list: {
     border: `2px solid ${palette.grey.medium}`,


### PR DESCRIPTION
Our `Menu`'s are spec'd to be 8px offset from their anchor. My previous method of adjusting the inset of the entire popover was naive -- that element is inset to the screen, not an area. A top margin is better. It has to be applied conditionally by the consuming scenario, so I defined a utility class. Ideally we could define something that covers all scenarios, but I haven't figured that yet.