### PR TITLE
refactor(InputBase): rename success class, switch padded element

### DIFF
--- a/libs/spark/src/InputBase.tsx
+++ b/libs/spark/src/InputBase.tsx
@@ -9,7 +9,6 @@ export const MuiInputBaseStyleOverrides = {
     borderColor: palette.grey.medium,
     borderRadius: 8,
     width: '20rem', // 320px
-    padding: '.75rem 1rem',
     margin: 4, // potential box-shadow width
     fontSize: '1rem', // 16px
     lineHeight: '1.125rem', // 18px
@@ -18,7 +17,7 @@ export const MuiInputBaseStyleOverrides = {
       boxShadow: `0 0 0 4px ${palette.blue[1]}`,
       backgroundColor: palette.common.white,
     },
-    '&.SparkInput-success': {
+    '&.Spark-success': {
       borderColor: palette.green[3],
       boxShadow: `0 0 0 4px ${palette.green[1]}`,
     },
@@ -32,7 +31,8 @@ export const MuiInputBaseStyleOverrides = {
     },
   },
   input: {
-    padding: 0,
+    padding: '.75rem 1rem',
+    borderRadius: 8,
     color: palette.text.onLight,
     '&::placeholder': {
       color: palette.text.onLightLowContrast,

--- a/libs/spark/stories/input.stories.tsx
+++ b/libs/spark/stories/input.stories.tsx
@@ -49,15 +49,15 @@ const StatesTemplate: Story = ({ pseudo, ...args }) => (
       <Input multiline rows={3} value="Value" {...args} />
     </InnerGroup>
     <InnerGroup>
-      <Input className={'SparkInput-success'} {...args} />
-      <Input className={'SparkInput-success'} value="Value" {...args} />
+      <Input className="Spark-success" {...args} />
+      <Input className="Spark-success" value="Value" {...args} />
     </InnerGroup>
     <InnerGroup>
-      <Input multiline rows={3} className={'SparkInput-success'} {...args} />
+      <Input multiline rows={3} className="Spark-success" {...args} />
       <Input
         multiline
         rows={3}
-        className={'SparkInput-success'}
+        className="Spark-success"
         value="Value"
         {...args}
       />


### PR DESCRIPTION
Renames `SparkInput-success` to `Spark-success` because 1) it's defined on `InputBase` now 2) it will extend to `Select` and other components that inherit from `InputBase` and 3) mirrors `Mui-error`.

Also switches from padding the root to the `input` element. This is necessary from an upcoming `Select` implementation.