### PR TITLE
feat(Select): initial implementation

### DIFF
--- a/libs/spark/src/Dropdown.tsx
+++ b/libs/spark/src/Dropdown.tsx
@@ -100,14 +100,6 @@ const SparkDropdownMenu = React.forwardRef<HTMLUListElement, DropdownMenuProps>(
         keepMounted
         onClose={handleClose}
         open={Boolean(anchorEl)}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
         ref={ref}
         PaperProps={{ className: 'SparkMenu-paperOffsetTop' }}
         {...other}

--- a/libs/spark/src/Select.ts
+++ b/libs/spark/src/Select.ts
@@ -1,0 +1,36 @@
+import { ChevronDownIconLine } from './icons';
+import { palette } from './styles/palette';
+
+export const MuiSelectDefaultProps = {
+  IconComponent: ChevronDownIconLine,
+  MenuProps: {
+    getContentAnchorEl: null,
+    anchorOrigin: {
+      vertical: 'bottom',
+      horizontal: 'right',
+    },
+    transformOrigin: {
+      vertical: 'top',
+      horizontal: 'right',
+    },
+    classes: { paper: 'Spark-offsetTop' },
+  },
+};
+
+export const MuiSelectStylesOverrides = {
+  root: {
+    color: ({ value }) =>
+      value === '' ? palette.text.onLightLowContrast : palette.text.onLight,
+  },
+  select: {
+    borderRadius: 8,
+    '&:focus': {
+      borderRadius: 8,
+      backgroundColor: palette.common.white,
+    },
+  },
+  icon: {
+    marginRight: 14,
+    transition: 'transform 250ms ease',
+  },
+};

--- a/libs/spark/src/Select.ts
+++ b/libs/spark/src/Select.ts
@@ -6,12 +6,12 @@ export const MuiSelectDefaultProps = {
   MenuProps: {
     getContentAnchorEl: null,
     anchorOrigin: {
-      vertical: 'bottom',
-      horizontal: 'right',
+      vertical: 'bottom' as const,
+      horizontal: 'right' as const,
     },
     transformOrigin: {
-      vertical: 'top',
-      horizontal: 'right',
+      vertical: 'top' as const,
+      horizontal: 'right' as const,
     },
     classes: { paper: 'Spark-offsetTop' },
   },

--- a/libs/spark/src/icons/line/ChevronDown.js
+++ b/libs/spark/src/icons/line/ChevronDown.js
@@ -1,22 +1,15 @@
 import * as React from 'react';
+import { SvgIcon } from '@material-ui/core';
 
 function SvgChevronDown(props) {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="1em"
-      height="1em"
-      fill="none"
-      viewBox="0 0 24 24"
-      style={props.style}
-    >
+    <SvgIcon {...props}>
       <path
-        fill="currentcolor"
         fillRule="evenodd"
         d="M5.47 8.47a.75.75 0 011.06 0L12 13.94l5.47-5.47a.75.75 0 111.06 1.06l-6 6a.75.75 0 01-1.06 0l-6-6a.75.75 0 010-1.06z"
         clipRule="evenodd"
       />
-    </svg>
+    </SvgIcon>
   );
 }
 

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -15,6 +15,7 @@ import { MuiPaginationItemStyleOverrides } from '../PaginationItem';
 import { MuiRadioStyleOverrides } from '../Radio';
 import { MuiSvgIconStyleOverrides } from '../SvgIcon';
 import { fontFaces, typography } from './typography';
+import { MuiSelectStylesOverrides } from '../Select';
 
 export const overrides = {
   MuiButtonBase: MuiButtonBaseStyleOverrides,
@@ -41,5 +42,6 @@ export const overrides = {
   MuiPagination: MuiPaginationStyleOverrides,
   MuiPaginationItem: MuiPaginationItemStyleOverrides,
   MuiRadio: MuiRadioStyleOverrides,
+  MuiSelect: MuiSelectStylesOverrides,
   MuiSvgIcon: MuiSvgIconStyleOverrides,
 };

--- a/libs/spark/src/styles/props.ts
+++ b/libs/spark/src/styles/props.ts
@@ -6,6 +6,7 @@ import { MuiMenuDefaultProps } from '../Menu';
 import { MuiPaginationDefaultProps } from '../Pagination';
 import { MuiPaginationItemDefaultProps } from '../PaginationItem';
 import { MuiRadioDefaultProps } from '../Radio';
+import { MuiSelectDefaultProps } from '../Select';
 import { MuiSvgIconDefaultProps } from '../SvgIcon';
 
 export const props = {
@@ -17,5 +18,6 @@ export const props = {
   MuiPagination: MuiPaginationDefaultProps,
   MuiPaginationItem: MuiPaginationItemDefaultProps,
   MuiRadio: MuiRadioDefaultProps,
+  MuiSelect: MuiSelectDefaultProps,
   MuiSvgIcon: MuiSvgIconDefaultProps,
 };

--- a/libs/spark/stories/select.stories.tsx
+++ b/libs/spark/stories/select.stories.tsx
@@ -63,8 +63,8 @@ const StatesTemplate: Story = ({ pseudo, ...args }) => (
       <Template {...args} value="value" />
     </InnerGroup>
     <InnerGroup>
-      <Template {...args} className="SparkInputBase-success" value="" />
-      <Template {...args} className="SparkInputBase-success" value="value" />
+      <Template {...args} className="Spark-success" value="" />
+      <Template {...args} className="Spark-success" value="value" />
     </InnerGroup>
     <InnerGroup>
       <Template {...args} error value="" />

--- a/libs/spark/stories/select.stories.tsx
+++ b/libs/spark/stories/select.stories.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Story } from '@storybook/react';
+import { Meta } from '@storybook/react/types-6-0';
+import { Select, styled, MenuItem } from '@material-ui/core';
+
+export default {
+  title: 'prenda-spark/Select',
+  component: Select,
+  parameters: { actions: { handles: ['change'] } },
+  argTypes: {
+    value: { control: 'text' },
+    displayEmpty: { control: 'boolean' },
+    error: { control: 'boolean' },
+    success: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    open: { control: 'boolean' },
+  },
+  args: {
+    value: '',
+    displayEmpty: true,
+  },
+} as Meta;
+
+const Template: Story = ({ value: propValue, ...args }) => {
+  const [value, setValue] = React.useState(propValue);
+
+  const handleChange = (event) => setValue(event.target.value);
+
+  return (
+    <Select value={value} {...args} onChange={handleChange}>
+      <MenuItem value="" disabled>
+        Placeholder
+      </MenuItem>
+      <MenuItem value="value">Option</MenuItem>
+      <MenuItem value="valueB">Option B</MenuItem>
+      <MenuItem value="valueC">Option C</MenuItem>
+    </Select>
+  );
+};
+
+export const Configurable = Template.bind({});
+Configurable.decorators = [(Story) => <Story />];
+
+const OuterGroup = styled('span')({
+  display: 'flex',
+  flexDirection: 'column',
+  flexWrap: 'wrap',
+  gap: '1rem',
+  margin: '1rem',
+});
+
+const InnerGroup = styled('span')({
+  display: 'flex',
+  alignItems: 'flex-start',
+  flexWrap: 'wrap',
+  gap: '1rem',
+});
+
+const StatesTemplate: Story = ({ pseudo, ...args }) => (
+  <OuterGroup>
+    <InnerGroup>
+      <Template {...args} value="" />
+      <Template {...args} value="value" />
+    </InnerGroup>
+    <InnerGroup>
+      <Template {...args} className="SparkInputBase-success" value="" />
+      <Template {...args} className="SparkInputBase-success" value="value" />
+    </InnerGroup>
+    <InnerGroup>
+      <Template {...args} error value="" />
+      <Template {...args} error value="value" />
+    </InnerGroup>
+    {pseudo ? null : (
+      <InnerGroup>
+        <Template {...args} disabled value="" />
+        <Template {...args} disabled value="value" />
+      </InnerGroup>
+    )}
+  </OuterGroup>
+);
+
+export const States = StatesTemplate.bind({});
+
+export const StatesFocus = StatesTemplate.bind({});
+StatesFocus.args = { pseudo: true };
+StatesFocus.parameters = { pseudo: { focus: true } };
+
+export const Open = Template.bind({});
+Open.args = { open: true };


### PR DESCRIPTION
~Draft until required #121 and #122 are merged~

Closes #123

Implementing placeholder text and its styling is fairly tricky. It's not even really part of normal HTML. You have to give a default, disabled value option (`value=""`), an empty string as your initial state, and let Mui know you want to display that default value.

Storybook was also wigging out on controlling the `value` state by itself, so I had to add a basic hook for that.

The styling for "Placeholder" text is dynamic unfortunately, because it's not a placeholder like I said, and I couldn't write a style rule like `input[value=""] + & { }` because the `input` element comes _after_ the actually displayed `div`, and CSS doesn't have a "previous sibling" selector, or previous in general. If y'all have a suggestion that doesn't use a dynamic prop check, lmk! If not, I'll eventually submit a issue request to Mui to see if they'll re-order it. 

The `Dropdown` and `IconButton` stories changed in snapshots because I corrected the implementation of the `DownChevronIcon`,