### PR TITLE
chore(nx): generate new project, spark-icons (@prenda/spark-icons)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
           "error",
           {
             "enforceBuildableLibDependency": true,
-            "allow": [],
+            "allow": ["@prenda/spark-icons", "@prenda/spark-icons/*"],
             "depConstraints": [
               {
                 "sourceTag": "*",

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  projects: ['<rootDir>/libs/spark'],
+  projects: ['<rootDir>/libs/spark', '<rootDir>/libs/spark-icons'],
 };

--- a/libs/spark-icons/.babelrc
+++ b/libs/spark-icons/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@nrwl/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage"
+      }
+    ]
+  ],
+  "plugins": []
+}

--- a/libs/spark-icons/.eslintrc.json
+++ b/libs/spark-icons/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["plugin:@nrwl/nx/react", "../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/spark-icons/README.md
+++ b/libs/spark-icons/README.md
@@ -1,0 +1,7 @@
+# spark-icons
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test spark-icons` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/spark-icons/jest.config.js
+++ b/libs/spark-icons/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  displayName: 'spark-icons',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/spark-icons',
+};

--- a/libs/spark-icons/package.json
+++ b/libs/spark-icons/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@prenda/spark-icons",
+  "version": "0.0.1"
+}

--- a/libs/spark-icons/tsconfig.json
+++ b/libs/spark-icons/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/spark-icons/tsconfig.lib.json
+++ b/libs/spark-icons/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "files": [
+    "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/libs/spark-icons/tsconfig.spec.json
+++ b/libs/spark-icons/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -9,7 +9,7 @@
   "affected": {
     "defaultBase": "main"
   },
-  "npmScope": "prenda-spark",
+  "npmScope": "prenda",
   "tasksRunnerOptions": {
     "default": {
       "runner": "@nrwl/workspace/tasks-runners/default",

--- a/nx.json
+++ b/nx.json
@@ -34,6 +34,9 @@
     },
     "workspace": {
       "tags": []
+    },
+    "spark-icons": {
+      "tags": []
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,8 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "@prenda/spark": ["libs/spark/src/index.ts"]
+      "@prenda/spark": ["libs/spark/src/index.ts"],
+      "@prenda/spark-icons": ["libs/spark-icons/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,7 +17,8 @@
     "baseUrl": ".",
     "paths": {
       "@prenda/spark": ["libs/spark/src/index.ts"],
-      "@prenda/spark-icons": ["libs/spark-icons/src/index.ts"]
+      "@prenda/spark-icons": ["libs/spark-icons/src/index.ts"],
+      "@prenda/spark-icons/*": ["libs/spark-icons/src/*"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/workspace.json
+++ b/workspace.json
@@ -138,6 +138,46 @@
         }
       },
       "root": "."
+    },
+    "spark-icons": {
+      "root": "libs/spark-icons",
+      "sourceRoot": "libs/spark-icons/src",
+      "projectType": "library",
+      "targets": {
+        "build": {
+          "executor": "@nrwl/web:package",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "outputPath": "dist/libs/spark-icons",
+            "tsConfig": "libs/spark-icons/tsconfig.lib.json",
+            "project": "libs/spark-icons/package.json",
+            "entryFile": "libs/spark-icons/src/index.ts",
+            "external": ["react/jsx-runtime"],
+            "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+            "assets": [
+              {
+                "glob": "libs/spark-icons/README.md",
+                "input": ".",
+                "output": "."
+              }
+            ]
+          }
+        },
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": ["libs/spark-icons/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/spark-icons"],
+          "options": {
+            "jestConfig": "libs/spark-icons/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## 1 of 4
This is the first of four PRs that will make up an address to #73. They're separated primarily to make each sensibly reviewable, and also for respective merge commits to paint a better picture. Each PR will be marked as Draft until the previous is merged and the next can be rebased off `main`. You can effectively review each PR by commit.

**1. Project generation (this PR)**
2. Copying of icon utility scripts from Mui & Modification for our use case (#133)
3. Removal of icons from @prenda/spark & Specific generation and replacement of depended-on icons (#134)
4. Addition of all icons in @prenda/spark-icons (#135)

## In this step
### Preface
I corrected the `"npmScope"` listed in `nx.json` from `"prenda-spark"` to `"prenda"` (no "@" needed, see @nrwl/nx's setup).

### Project generation
Generated a new NX project, namely a react component library with no styling solution.
```bash
> npx nx g @nrwl/react:lib --publishable --importPath @prenda/spark-icons
✔ What name would you like to use for the library? · spark-icons
✔ Which stylesheet format would you like to use? · none
UPDATE workspace.json
UPDATE nx.json
CREATE libs/spark-icons/.eslintrc.json
CREATE libs/spark-icons/.babelrc
CREATE libs/spark-icons/README.md
CREATE libs/spark-icons/package.json
CREATE libs/spark-icons/src/index.ts
CREATE libs/spark-icons/tsconfig.json
CREATE libs/spark-icons/tsconfig.lib.json
UPDATE tsconfig.base.json
CREATE libs/spark-icons/jest.config.js
CREATE libs/spark-icons/tsconfig.spec.json
UPDATE jest.config.js
CREATE libs/spark-icons/src/lib/spark-icons.spec.tsx
CREATE libs/spark-icons/src/lib/spark-icons.tsx
```
The exact options and steps above turned out to be necessary. All together they are what allow for projects within our NX monorepo to validly reference the icons package. Otherwise, NX will complain that we cannot import from `@prenda/spark-icons` in any file under `libs/spark/*` because "a buildable library cannot import or export from non-buildable libraries" by way of it's "enforce-module-boundaries" lint rule.
- To allow deep imports like `import ChevronDownIcon from '@prenda/spark-icons/ChevronDown`, and to specifically address the above linting errors, the last commit adds some additional rules in `tsconfig.base.json` and `.eslintrc.json`
- We primarily would use the icons in our story files, but also sometimes in component files. We'll have to see what the consequences of that are in publishing these packages -- Mui moves all icons used in the core package under `internal/` and doesn't pull in their icons package; there isn't overlap between the two for them, but there is for us, so we have a better reason.
  - We almost only use our icons in stories, which don't need to be under the spark library, and can be relocated 