### PR TITLE
feat(spark-icons): build to be path-import friendly without tree-shaking

### DIFF
--- a/libs/spark-icons/defaults/babel.config.js
+++ b/libs/spark-icons/defaults/babel.config.js
@@ -19,18 +19,48 @@ if (process.env.BABEL_ENV === 'es') {
   ];
 }
 
+const productionPlugins = [
+  '@babel/plugin-transform-react-constant-elements',
+  'babel-plugin-transform-dev-warning',
+];
+
 module.exports = {
-  presets: defaultPresets,
-  plugins: [['@babel/plugin-proposal-class-properties', { loose: true }]],
+  presets: defaultPresets.concat([
+    '@babel/preset-react',
+    '@babel/preset-typescript',
+  ]),
+  plugins: [
+    ['@babel/plugin-proposal-class-properties', { loose: true }],
+    ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
+    ['@babel/plugin-transform-runtime', { version: '^7.4.4' }],
+  ],
   env: {
     cjs: {
-      plugins: [],
+      plugins: productionPlugins,
     },
     es: {
-      plugins: [['@babel/plugin-transform-runtime', { useESModules: true }]],
+      plugins: [
+        ...productionPlugins,
+        ['@babel/plugin-transform-runtime', { useESModules: true }],
+      ],
     },
     esm: {
-      plugins: [['@babel/plugin-transform-runtime', { useESModules: true }]],
+      plugins: [
+        ...productionPlugins,
+        ['@babel/plugin-transform-runtime', { useESModules: true }],
+      ],
+    },
+    production: {
+      plugins: [
+        ...productionPlugins,
+        ['@babel/plugin-transform-runtime', { useESModules: true }],
+      ],
+    },
+    'production-umd': {
+      plugins: [
+        ...productionPlugins,
+        ['@babel/plugin-transform-runtime', { useESModules: true }],
+      ],
     },
   },
 };

--- a/libs/spark-icons/defaults/babel.config.js
+++ b/libs/spark-icons/defaults/babel.config.js
@@ -19,10 +19,7 @@ if (process.env.BABEL_ENV === 'es') {
   ];
 }
 
-const productionPlugins = [
-  '@babel/plugin-transform-react-constant-elements',
-  'babel-plugin-transform-dev-warning',
-];
+const productionPlugins = ['@babel/plugin-transform-react-constant-elements'];
 
 module.exports = {
   presets: defaultPresets.concat([

--- a/libs/spark-icons/package.json
+++ b/libs/spark-icons/package.json
@@ -1,5 +1,22 @@
 {
   "name": "@prenda/spark-icons",
   "version": "0.0.1",
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
+  },
+  "peerDependencies": {
+    "@material-ui/core": "^4.0.0",
+    "react": "^16.8.0 || ^17.0.0"
+  },
+  "devDependencies": {
+    "fs-extra": "^10.0.0",
+    "glob": "^7.1.7",
+    "mustache": "^4.2.0",
+    "path": "^0.12.7",
+    "rimraf": "^3.0.2",
+    "svgo": "^2.3.1",
+    "temp": "^0.9.4",
+    "yargs": "^17.0.1"
+  }
 }

--- a/libs/spark-icons/scripts/copy-files.js
+++ b/libs/spark-icons/scripts/copy-files.js
@@ -1,0 +1,121 @@
+/* eslint-disable no-console */
+const path = require('path');
+const fse = require('fs-extra');
+const glob = require('glob');
+
+const packagePath = process.cwd();
+const buildPath = path.join(packagePath, './dist/libs/spark-icons-2');
+const srcPath = path.join(packagePath, './libs/spark-icons/src');
+
+async function includeFileInBuild(file) {
+  const sourcePath = path.resolve(packagePath, file);
+  const targetPath = path.resolve(buildPath, path.basename(file));
+  await fse.copy(sourcePath, targetPath);
+  console.log(`Copied ${sourcePath} to ${targetPath}`);
+}
+
+/**
+ * Puts a package.json into every immediate child directory of rootDir.
+ * That package.json contains information about esm for bundlers so that imports
+ * like import Typography from '@material-ui/core/Typography' are tree-shakeable.
+ *
+ * It also tests that an this import can be used in typescript by checking
+ * if an index.d.ts is present at that path.
+ *
+ * @param {string} rootDir
+ */
+async function createModulePackages({ from, to }) {
+  const directoryPackages = glob
+    .sync('*/index.js', { cwd: from })
+    .map(path.dirname);
+
+  await Promise.all(
+    directoryPackages.map(async (directoryPackage) => {
+      const packageJson = {
+        sideEffects: false,
+        module: path.posix.join('../esm', directoryPackage, 'index.js'),
+        typings: './index.d.ts',
+      };
+      const packageJsonPath = path.join(to, directoryPackage, 'package.json');
+
+      const [typingsExist] = await Promise.all([
+        fse.exists(path.join(to, directoryPackage, 'index.d.ts')),
+        fse.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2)),
+      ]);
+
+      if (!typingsExist) {
+        throw new Error(`index.d.ts for ${directoryPackage} is missing`);
+      }
+
+      return packageJsonPath;
+    })
+  );
+}
+
+async function typescriptCopy({ from, to }) {
+  if (!(await fse.exists(to))) {
+    console.warn(`path ${to} does not exists`);
+    return [];
+  }
+
+  const files = glob.sync('**/*.d.ts', { cwd: from });
+  const cmds = files.map((file) =>
+    fse.copy(path.resolve(from, file), path.resolve(to, file))
+  );
+  return Promise.all(cmds);
+}
+
+async function createPackageFile() {
+  const packageData = await fse.readFile(
+    path.resolve(packagePath, './libs/spark-icons/package.json'),
+    'utf8'
+  );
+  const {
+    nyc,
+    scripts,
+    devDependencies,
+    workspaces,
+    ...packageDataOther
+  } = JSON.parse(packageData);
+  const newPackageData = {
+    ...packageDataOther,
+    private: false,
+    main: './index.js',
+    module: './esm/index.js',
+    typings: './index.d.ts',
+  };
+  const targetPath = path.resolve(buildPath, './package.json');
+
+  await fse.writeFile(
+    targetPath,
+    JSON.stringify(newPackageData, null, 2),
+    'utf8'
+  );
+  console.log(`Created package.json in ${targetPath}`);
+
+  return newPackageData;
+}
+
+async function run() {
+  try {
+    await createPackageFile();
+
+    await Promise.all(
+      [
+        './libs/spark-icons/README.md',
+        // './libs/spark-icons/CHANGELOG.md',
+        // './libs/spark-icons/LICENSE',
+      ].map((file) => includeFileInBuild(file))
+    );
+
+    // TypeScript
+    await typescriptCopy({ from: srcPath, to: buildPath });
+
+    await createModulePackages({ from: srcPath, to: buildPath });
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/libs/spark-icons/scripts/copy-files.js
+++ b/libs/spark-icons/scripts/copy-files.js
@@ -4,7 +4,7 @@ const fse = require('fs-extra');
 const glob = require('glob');
 
 const packagePath = process.cwd();
-const buildPath = path.join(packagePath, './dist/libs/spark-icons-2');
+const buildPath = path.join(packagePath, './dist/libs/spark-icons-alt');
 const srcPath = path.join(packagePath, './libs/spark-icons/src');
 
 async function includeFileInBuild(file) {

--- a/libs/spark-icons/scripts/create-typings.js
+++ b/libs/spark-icons/scripts/create-typings.js
@@ -7,7 +7,10 @@ import fse from 'fs-extra';
 import glob from 'glob';
 
 const SRC_DIR = path.resolve(__dirname, '../src');
-const TARGET_DIR = path.resolve(__dirname, '../../../dist/libs/spark-icons-2');
+const TARGET_DIR = path.resolve(
+  __dirname,
+  '../../../dist/libs/spark-icons-alt'
+);
 
 function normalizeFileName(file) {
   return path.parse(file).name;

--- a/libs/spark-icons/scripts/create-typings.js
+++ b/libs/spark-icons/scripts/create-typings.js
@@ -1,0 +1,54 @@
+// Original credit to https://github.com/mui-org/material-ui/blob/1c5beec4be20eae30e75c69ab513bbfec3e9baaf/packages/material-ui-icons/scripts/create-typings.js
+
+/* eslint-disable no-console */
+import path from 'path';
+import chalk from 'chalk';
+import fse from 'fs-extra';
+import glob from 'glob';
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+const TARGET_DIR = path.resolve(__dirname, '../../../dist/libs/spark-icons-2');
+
+function normalizeFileName(file) {
+  return path.parse(file).name;
+}
+
+function createIconTyping(file) {
+  const name = normalizeFileName(file);
+  const contents = `export { default } from '@material-ui/core/SvgIcon';`;
+  return fse.writeFile(
+    path.resolve(TARGET_DIR, `${name}.d.ts`),
+    contents,
+    'utf8'
+  );
+}
+
+function createIndexTyping(files) {
+  const contents = `
+import SvgIcon from '@material-ui/core/SvgIcon';
+type SvgIconComponent = typeof SvgIcon;
+${files
+  .map((file) => `export const ${normalizeFileName(file)}: SvgIconComponent;`)
+  .join('\n')}
+`;
+
+  return fse.writeFile(
+    path.resolve(TARGET_DIR, 'index.d.ts'),
+    contents,
+    'utf8'
+  );
+}
+
+// Generate TypeScript.
+async function run() {
+  await fse.ensureDir(TARGET_DIR);
+  console.log(
+    `\u{1f52c}  Searching for modules inside "${chalk.dim(SRC_DIR)}".`
+  );
+  const files = glob.sync('*.tsx', { cwd: SRC_DIR });
+  const typings = files.map((file) => createIconTyping(file));
+  await Promise.all([...typings, createIndexTyping(files)]);
+  console.log(`\u{1F5C4}  Written typings to ${chalk.dim(TARGET_DIR)}.`);
+}
+
+run();

--- a/libs/spark/package.json
+++ b/libs/spark/package.json
@@ -2,5 +2,15 @@
   "name": "@prenda/spark",
   "version": "0.8.0",
   "author": "Prenda",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "clsx": "^1.1.1",
+    "styled-components": "5.2.1"
+  },
+  "peerDependencies": {
+    "@material-ui/core": "^4.0.0",
+    "react": "^16.8.0 || ^17.0.0",
+    "@prenda/spark-icons": "^0.0.1",
+    "@material-ui/lab": "^4.0.0"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,6 +299,14 @@
             }
           }
         },
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "@ngtools/webpack": {
           "version": "12.0.3",
           "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.0.3.tgz",
@@ -2840,15 +2848,56 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.2.tgz",
-      "integrity": "sha512-hBIQFxwZi8GIp934+nj5uV31mqclC1aYDhctDu5khTi9PCCUOczyy0b34W0oE9U/eJXiqQaKyVsmjeagOaSlbw==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
+      "integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
       "requires": {
-        "@babel/compat-data": "^7.14.0",
-        "@babel/helper-compilation-targets": "^7.13.16",
-        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/compat-data": "^7.14.7",
+        "@babel/helper-compilation-targets": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.14.2"
+        "@babel/plugin-transform-parameters": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/compat-data": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+          "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+          "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+          "requires": {
+            "@babel/compat-data": "^7.14.5",
+            "@babel/helper-validator-option": "^7.14.5",
+            "browserslist": "^4.16.6",
+            "semver": "^6.3.0"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+        },
+        "@babel/helper-validator-option": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+          "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
+          "integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.14.5"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -3289,12 +3338,20 @@
       }
     },
     "@babel/plugin-transform-react-constant-elements": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.13.13.tgz",
-      "integrity": "sha512-SNJU53VM/SjQL0bZhyU+f4kJQz7bQQajnrZRSaU21hruG/NWY41AEM9AWXeXX90pYr/C2yAmTgI6yW3LlLrAUQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.14.5.tgz",
+      "integrity": "sha512-NBqLEx1GxllIOXJInJAQbrnwwYJsV3WaMHIcOwD8rhYS0AabTWn7kHdHgPgu5RmHLU0q4DMxhAMu8ue/KampgQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0"
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -3737,9 +3794,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "help": "nx help",
     "prepare": "husky install",
     "src:icons": "UV_THREADPOOL_SIZE=64 babel-node --config-file ./libs/spark-icons/defaults/babel.config.js libs/spark-icons/scripts/builder.js --output-dir libs/spark-icons/src --svg-dir libs/spark-icons/svg-files",
-    "build:icons": "rimraf ./dist/libs/spark-icons-2 && npm run build:icons:envs && npm run build:icons-typings && npm run build:icons-copy-files",
-    "build:icons:envs": "NODE_ENV=\"production\" BABEL_ENV=\"cjs\" babel --config-file ./libs/spark-icons/defaults/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons-2 && BABEL_ENV=\"esm\" babel --config-file ./libs/spark-icons/defaults/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons-2/esm",
+    "build:icons": "rimraf ./dist/libs/spark-icons-alt && npm run build:icons:envs && npm run build:icons-typings && npm run build:icons-copy-files",
+    "build:icons:envs": "NODE_ENV=\"production\" BABEL_ENV=\"cjs\" babel --config-file ./libs/spark-icons/defaults/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons-alt && BABEL_ENV=\"esm\" babel --config-file ./libs/spark-icons/defaults/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons-alt/esm",
     "build:icons-typings": "babel-node --config-file ./libs/spark-icons/defaults/babel.config.js libs/spark-icons/scripts/create-typings.js",
     "build:icons-copy-files": "node ./libs/spark-icons/scripts/copy-files.js"
   },

--- a/package.json
+++ b/package.json
@@ -25,12 +25,17 @@
     "dep-graph": "nx dep-graph",
     "help": "nx help",
     "prepare": "husky install",
-    "src:icons": "UV_THREADPOOL_SIZE=64 babel-node --config-file ./libs/spark-icons/defaults/babel.config.js libs/spark-icons/scripts/builder.js --output-dir libs/spark-icons/src --svg-dir libs/spark-icons/svg-files"
+    "src:icons": "UV_THREADPOOL_SIZE=64 babel-node --config-file ./libs/spark-icons/defaults/babel.config.js libs/spark-icons/scripts/builder.js --output-dir libs/spark-icons/src --svg-dir libs/spark-icons/svg-files",
+    "build:icons": "rimraf ./dist/libs/spark-icons-2 && npm run build:icons:envs && npm run build:icons-typings && npm run build:icons-copy-files",
+    "build:icons:envs": "NODE_ENV=\"production\" BABEL_ENV=\"cjs\" babel --config-file ./libs/spark-icons/defaults/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons-2 && BABEL_ENV=\"esm\" babel --config-file ./libs/spark-icons/defaults/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons-2/esm",
+    "build:icons-typings": "babel-node --config-file ./libs/spark-icons/defaults/babel.config.js libs/spark-icons/scripts/create-typings.js",
+    "build:icons-copy-files": "node ./libs/spark-icons/scripts/copy-files.js"
   },
   "private": true,
   "dependencies": {
     "@angular-devkit/build-angular": "^12.0.3",
     "@angular-devkit/schematics": "^12.0.5",
+    "@babel/runtime": "^7.14.6",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
@@ -50,6 +55,8 @@
     "@babel/core": "7.12.13",
     "@babel/node": "^7.14.7",
     "@babel/plugin-proposal-class-properties": "^7.14.5",
+    "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
+    "@babel/plugin-transform-react-constant-elements": "^7.14.5",
     "@babel/plugin-transform-runtime": "^7.14.5",
     "@babel/preset-env": "7.12.13",
     "@babel/preset-react": "7.12.13",


### PR DESCRIPTION
## 5 of 4

Followup to #135
Closes #138 

Using Nx, `nx run spark-icons:build` produces a tree-shakable bundle, but does not produce a bundle that's ideal for path imports and use with non-tree-shaking bundlers, like Meteor.

The resolution is to again copy and modify what Mui does.

The result is that `@prenda/spark-icons` should now be built from the command `npm run build:icons` issued at the repo root. The build output is sent to `dist/libs/spark-icons-alt` since the Nx build currently occupies the `dist/libs/spark-icons` path.

### Visual representation
`> nx run spark-icons:build` produces _n_ TS declaration files BUT _1_ file for each bundle type
![image](https://user-images.githubusercontent.com/25781782/125857676-cc6ca26b-9c87-4652-a3f7-04422eedcadc.png)
![image](https://user-images.githubusercontent.com/25781782/125857689-e219d9fd-e6e7-483f-9fce-5cb4f06be18b.png)

vs.

`> npm run icons:build` produces _n_ TS declaration files AND _n_ files
![image](https://user-images.githubusercontent.com/25781782/125857716-306c62d5-660c-4a9c-834a-12f5609fdcdb.png)
![image](https://user-images.githubusercontent.com/25781782/125857722-d1a43df8-5dee-4b10-9f87-526e6ef1fc8b.png)

