### PR TITLE
feat(Button): update stylings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/libs/spark/src/icons/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 
 /dist
 /coverage
+/libs/spark/src/icons/*

--- a/libs/spark/src/Button.tsx
+++ b/libs/spark/src/Button.tsx
@@ -34,34 +34,27 @@ const SparkButton: FC<ButtonProps> = ({
       )}
       {...other}
     >
-      {/* FROM-MUI
-       * The inner <span> is required to vertically align the children.
-       * Browsers don't support `display: flex` on a <button> element.
-       * https://github.com/philipwalton/flexbugs/blob/master/README.md#flexbug-9
-       */}
-      <span className="SparkButton-content">
-        {startIcon ? (
-          <span
-            className={clsx(
-              'SparkButton-startIcon',
-              `SparkButton-iconSize${capitalize(size)}`
-            )}
-          >
-            {startIcon}
-          </span>
-        ) : null}
-        {children}
-        {endIcon ? (
-          <span
-            className={clsx(
-              'SparkButton-endIcon',
-              `SparkButton-iconSize${capitalize(size)}`
-            )}
-          >
-            {endIcon}
-          </span>
-        ) : null}
-      </span>
+      {startIcon ? (
+        <span
+          className={clsx(
+            'SparkButton-startIcon',
+            `SparkButton-iconSize${capitalize(size)}`
+          )}
+        >
+          {startIcon}
+        </span>
+      ) : null}
+      {children}
+      {endIcon ? (
+        <span
+          className={clsx(
+            'SparkButton-endIcon',
+            `SparkButton-iconSize${capitalize(size)}`
+          )}
+        >
+          {endIcon}
+        </span>
+      ) : null}
     </ButtonBase>
   );
 };

--- a/libs/spark/src/Button.tsx
+++ b/libs/spark/src/Button.tsx
@@ -2,9 +2,7 @@ import React, { FC } from 'react';
 import {
   ButtonBase,
   ButtonBaseProps as MuiButtonBaseProps,
-  Theme,
 } from '@material-ui/core';
-import styled from 'styled-components';
 import clsx from 'clsx';
 import { capitalize } from './utils';
 
@@ -18,7 +16,7 @@ export interface ButtonProps extends MuiButtonBaseProps {
 const SparkButton: FC<ButtonProps> = ({
   className,
   variant = 'solid',
-  size = 'medium',
+  size = 'large',
   children,
   startIcon,
   endIcon,

--- a/libs/spark/src/ButtonBase.ts
+++ b/libs/spark/src/ButtonBase.ts
@@ -19,13 +19,12 @@ export const MuiButtonBaseStyleOverrides = {
       borderWidth: '2px',
       borderStyle: 'solid' as const,
       fontWeight: 700,
-      '&.Mui-focusVisible': {
+      '&.Mui-focusVisible, &:focus': {
         boxShadow: `0 0 0 4px ${palette.blue[1]}`,
       },
       '&$disabled': {
         opacity: '50%',
       },
-
       '&.SparkButton-variantSolid': {
         borderColor: palette.blue[3],
         backgroundColor: palette.blue[3],
@@ -33,6 +32,9 @@ export const MuiButtonBaseStyleOverrides = {
         '&:hover': {
           borderColor: palette.blue[4],
           backgroundColor: palette.blue[4],
+        },
+        '&:active': {
+          borderColor: palette.blue[5],
         },
       },
       '&.SparkButton-variantOutlined': {
@@ -42,6 +44,9 @@ export const MuiButtonBaseStyleOverrides = {
         '&:hover': {
           backgroundColor: palette.grey.light,
         },
+        '&:active': {
+          borderColor: palette.blue[5],
+        },
       },
       '&.SparkButton-variantFlat': {
         borderColor: 'transparent',
@@ -50,15 +55,18 @@ export const MuiButtonBaseStyleOverrides = {
         '&:hover': {
           color: palette.blue[4],
         },
-        '&.Mui-focusVisible': {
+        '&.Mui-focusVisible, &:focus': {
           borderColor: palette.blue[3],
           backgroundColor: palette.blue[1],
+        },
+        '&:active': {
+          color: palette.blue[5],
         },
       },
       // Y-paddings are subtracted by 2 to account for border-width
       '&.SparkButton-sizeLarge': {
         fontSize: '1.125rem', // 18px
-        lineHeight: '1.25rem', // 20px
+        lineHeight: '1.5rem', // 20px
         padding: '.75rem 1rem', // 12px (accounting for 2px border width) 16px
       },
       '&.SparkButton-sizeMedium': {
@@ -68,32 +76,41 @@ export const MuiButtonBaseStyleOverrides = {
       },
       '&.SparkButton-sizeSmall': {
         fontSize: '0.75rem', // 12px
-        lineHeight: '0.75rem', // 12px
-        padding: '.25rem 1rem', // 4px (accounting for 2px border width) 16px
+        lineHeight: '1rem', // 12px
+        padding: '.125rem 1rem', // 4px (accounting for 2px border width) 16px
       },
-      '& .SparkButton-content': {
-        // taken from Mui
-        width: '100%', // Ensure the correct width for iOS Safari
+      '& .SparkButton-startIcon, & .SparkButton-endIcon': {
         display: 'inherit',
-        alignItems: 'inherit',
-        justifyContent: 'inherit',
-        '& .SparkButton-startIcon': {
-          display: 'inherit',
-          marginRight: '.5rem', // 8px
+        '.SparkButton-variantSolid& > .MuiSvgIcon-root': {
+          color: palette.common.white,
         },
-        '& .SparkButton-endIcon': {
-          display: 'inherit',
-          marginLeft: '.5rem', // 8px
+        '.SparkButton-variantOutlined& > .MuiSvgIcon-root': {
+          color: palette.blue[3],
         },
-        '& .SparkButton-iconSizeSmall': {
-          fontSize: '1rem', // 16px
+        '.SparkButton-variantFlat& > .MuiSvgIcon-root': {
+          color: palette.blue[3],
+          '&:hover': {
+            color: palette.blue[4],
+          },
+          '&:active': {
+            color: palette.blue[4],
+          },
         },
-        '& .SparkButton-iconSizeMedium': {
-          fontSize: '1.25rem', // 20px
-        },
-        '& .SparkButton-iconSizeLarge': {
-          fontSize: '1.5rem', // 24px
-        },
+      },
+      '& .SparkButton-startIcon': {
+        marginRight: 8,
+      },
+      '& .SparkButton-endIcon': {
+        marginLeft: 8,
+      },
+      '& .SparkButton-iconSizeSmall > .MuiSvgIcon-root': {
+        fontSize: '1rem', // 16px
+      },
+      '& .SparkButton-iconSizeMedium > .MuiSvgIcon-root': {
+        fontSize: '1.25rem', // 20px
+      },
+      '& .SparkButton-iconSizeLarge > .MuiSvgIcon-root': {
+        fontSize: '1.5rem', // 24px
       },
     },
   },

--- a/libs/spark/stories/button.stories.tsx
+++ b/libs/spark/stories/button.stories.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import * as React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 import { Button, ButtonProps } from '../src';
 import { ChevronDownIconLine } from '../src/icons';
+import Box from '@material-ui/core/Box';
 
 export default {
   title: 'prenda-spark/Button',
@@ -9,30 +10,22 @@ export default {
   argTypes: {
     onClick: { actions: 'clicked' },
     variant: {
-      control: {
-        type: 'select',
-        options: ['solid', 'outlined', 'flat'],
-      },
+      control: 'select',
+      options: ['solid', 'outlined', 'flat'],
     },
     size: {
-      control: {
-        type: 'select',
-        options: ['large', 'medium', 'small'],
-      },
+      control: 'select',
+      options: ['large', 'medium', 'small'],
     },
-    disabled: { control: 'boolean' },
     startIcon: {
-      control: {
-        type: 'select',
-        options: [undefined, 'caret-down'],
-      },
+      control: 'select',
+      options: [undefined, 'caret-down'],
     },
     endIcon: {
-      control: {
-        type: 'select',
-        options: [undefined, 'caret-down'],
-      },
+      control: 'select',
+      options: [undefined, 'caret-down'],
     },
+    disabled: { control: 'boolean' },
   },
   args: {
     variant: 'solid',
@@ -55,4 +48,132 @@ const Template = (args: TemplateButtonProps) => (
     Label
   </Button>
 );
-export const ConfigurableInput = Template.bind({});
+
+export const Configurable = Template.bind({});
+
+const GridContainer = (props) => (
+  <Box
+    m={1}
+    display="grid"
+    gridTemplateColumns="1fr 1fr 1fr 1fr"
+    gridGap="16px"
+    alignItems="end"
+    {...props}
+  />
+);
+
+const VariantAndSizeTemplate = (args) => (
+  <GridContainer>
+    <span>Variant / Size</span>
+    <span>Large</span>
+    <span>Medium</span>
+    <span>Small</span>
+
+    <span>Solid</span>
+    <span>
+      <Button {...args} variant="solid" size="large">
+        Label
+      </Button>
+    </span>
+    <span>
+      <Button {...args} variant="solid" size="medium">
+        Label
+      </Button>
+    </span>
+    <span>
+      <Button {...args} variant="solid" size="small">
+        Label
+      </Button>
+    </span>
+
+    <span>Outlined</span>
+    <span>
+      <Button {...args} variant="outlined" size="large">
+        Label
+      </Button>
+    </span>
+    <span>
+      <Button {...args} variant="outlined" size="medium">
+        Label
+      </Button>
+    </span>
+    <span>
+      <Button {...args} variant="outlined" size="small">
+        Label
+      </Button>
+    </span>
+
+    <span>Flat</span>
+    <span>
+      <Button {...args} variant="flat" size="large">
+        Label
+      </Button>
+    </span>
+    <span>
+      <Button {...args} variant="flat" size="medium">
+        Label
+      </Button>
+    </span>
+    <span>
+      <Button {...args} variant="flat" size="small">
+        Label
+      </Button>
+    </span>
+  </GridContainer>
+);
+
+export const VariantAndSize = VariantAndSizeTemplate.bind({});
+
+export const VariantAndSizeDisabled = VariantAndSizeTemplate.bind({});
+VariantAndSizeDisabled.args = { disabled: true };
+
+export const VariantAndSizeHover = VariantAndSizeTemplate.bind({});
+VariantAndSizeHover.parameters = { pseudo: { hover: true } };
+
+export const VariantAndSizeFocus = VariantAndSizeTemplate.bind({});
+VariantAndSizeFocus.parameters = { pseudo: { focus: true } };
+
+export const VariantAndSizeActive = VariantAndSizeTemplate.bind({});
+VariantAndSizeActive.parameters = { pseudo: { active: true } };
+
+export const StartIconVariantAndSize = VariantAndSizeTemplate.bind({});
+StartIconVariantAndSize.args = { startIcon: <ChevronDownIconLine /> };
+
+export const StartIconVariantAndSizeDisabled = VariantAndSizeTemplate.bind({});
+StartIconVariantAndSizeDisabled.args = {
+  disabled: true,
+  startIcon: <ChevronDownIconLine />,
+};
+
+export const StartIconVariantAndSizeHover = VariantAndSizeTemplate.bind({});
+StartIconVariantAndSizeHover.args = { startIcon: <ChevronDownIconLine /> };
+StartIconVariantAndSizeHover.parameters = { pseudo: { hover: true } };
+
+export const StartIconVariantAndSizeFocus = VariantAndSizeTemplate.bind({});
+StartIconVariantAndSizeFocus.args = { startIcon: <ChevronDownIconLine /> };
+StartIconVariantAndSizeFocus.parameters = { pseudo: { focus: true } };
+
+export const StartIconVariantAndSizeActive = VariantAndSizeTemplate.bind({});
+StartIconVariantAndSizeActive.args = { startIcon: <ChevronDownIconLine /> };
+StartIconVariantAndSizeActive.parameters = { pseudo: { active: true } };
+
+export const EndIconVariantAndSize = VariantAndSizeTemplate.bind({});
+EndIconVariantAndSize.args = { endIcon: <ChevronDownIconLine /> };
+
+export const EndIconVariantAndSizeDisabled = VariantAndSizeTemplate.bind({});
+EndIconVariantAndSizeDisabled.args = {
+  disabled: true,
+  endIcon: <ChevronDownIconLine />,
+};
+
+export const EndIconVariantAndSizeHover = VariantAndSizeTemplate.bind({});
+EndIconVariantAndSizeHover.args = { endIcon: <ChevronDownIconLine /> };
+EndIconVariantAndSizeHover.parameters = { pseudo: { hover: true } };
+
+export const EndIconVariantAndSizeFocus = VariantAndSizeTemplate.bind({});
+EndIconVariantAndSizeFocus.args = { endIcon: <ChevronDownIconLine /> };
+EndIconVariantAndSizeFocus.parameters = { pseudo: { focus: true } };
+
+export const EndIconVariantAndSizeActive = VariantAndSizeTemplate.bind({});
+EndIconVariantAndSizeActive.args = { endIcon: <ChevronDownIconLine /> };
+EndIconVariantAndSizeActive.parameters = { pseudo: { active: true } };


### PR DESCRIPTION
Part of #101 

- _Does not update the variant names to the new values_
- Adds `:active` styling
- Updates default values.
- Expands the stories to showcase all combinations of the Button's props.