### PR TITLE
feat(TextField): add theme-level style overrides

### DIFF
--- a/libs/spark/src/FormHelperText.ts
+++ b/libs/spark/src/FormHelperText.ts
@@ -5,12 +5,15 @@ export const MuiFormHelperTextStyleOverrides = {
     color: palette.text.onLightLowContrast,
     fontSize: '1rem', // 12px
     lineHeight: '1.5rem', // 20px
-    marginTop: 8,
+    marginTop: 4,
     '&$disabled': {
       color: palette.grey.dark,
     },
     '.MuiFormGroup-root ~ &': {
       marginTop: 3,
+    },
+    '.MuiTextField-root > &$error': {
+      color: palette.text.onLightLowContrast,
     },
   },
 };

--- a/libs/spark/src/FormLabel.ts
+++ b/libs/spark/src/FormLabel.ts
@@ -11,5 +11,8 @@ export const MuiFormLabelStyleOverrides = {
     '&$focused': {
       color: palette.blue[3],
     },
+    '&$error.MuiInputLabel-root': {
+      color: 'inherit',
+    },
   },
 };

--- a/libs/spark/src/Input.tsx
+++ b/libs/spark/src/Input.tsx
@@ -1,3 +1,12 @@
 export const MuiInputDefaultProps = {
   disableUnderline: true,
 };
+
+export const MuiInputStyleOverrides = {
+  formControl: {
+    marginLeft: 0,
+    'label + &': {
+      marginTop: 4,
+    },
+  },
+};

--- a/libs/spark/src/InputBase.tsx
+++ b/libs/spark/src/InputBase.tsx
@@ -17,7 +17,7 @@ export const MuiInputBaseStyleOverrides = {
       boxShadow: `0 0 0 4px ${palette.blue[1]}`,
       backgroundColor: palette.common.white,
     },
-    '&.Spark-success': {
+    '&.Spark-success, .MuiTextField-root.Spark-success > &': {
       borderColor: palette.green[3],
       boxShadow: `0 0 0 4px ${palette.green[1]}`,
     },
@@ -47,5 +47,14 @@ export const MuiInputBaseStyleOverrides = {
   },
   multiline: {
     padding: '.75rem 1rem',
+  },
+  formControl: {
+    // needs high specificity to override default !important
+    'label[data-shrink="false"] + &$root > $input::placeholder': {
+      opacity: '1 !important',
+    },
+    'label[data-shrink="false"] + &$root$disabled > $input::placeholder': {
+      opacity: '0.42 !important',
+    },
   },
 };

--- a/libs/spark/src/InputLabel.ts
+++ b/libs/spark/src/InputLabel.ts
@@ -1,13 +1,26 @@
 import { palette } from './styles/palette';
+
+export const MuiInputLabelDefaultProps = {
+  disableAnimation: true,
+};
+
 export const MuiInputLabelStyleOverrides = {
   root: {
     color: palette.text.onLight,
-    marginBottom: '0.5rem', // 8px
+    marginBottom: 4,
     fontWeight: 700,
     fontSize: '1rem', // 16px
     lineHeight: '1.125rem', // 18px
     '&$disabled': {
       color: palette.grey.dark,
     },
+  },
+  shrink: {
+    transform: 'none',
+    transformOrigin: 'unset',
+  },
+  formControl: {
+    transform: 'none',
+    position: 'relative' as const,
   },
 };

--- a/libs/spark/src/PaginationItem.ts
+++ b/libs/spark/src/PaginationItem.ts
@@ -67,7 +67,7 @@ export const MuiPaginationItemStyleOverrides = {
       paddingBottom: '.375rem',
       // extra for this being ::after
       visibility: 'visible',
-      position: 'absolute',
+      position: 'absolute' as const,
       inset: 'auto',
       content: "'...'",
       letterSpacing: '1px',

--- a/libs/spark/src/Select.ts
+++ b/libs/spark/src/Select.ts
@@ -2,6 +2,7 @@ import { ChevronDownIconLine } from './icons';
 import { palette } from './styles/palette';
 
 export const MuiSelectDefaultProps = {
+  displayEmpty: true,
   IconComponent: ChevronDownIconLine,
   MenuProps: {
     getContentAnchorEl: null,
@@ -19,8 +20,10 @@ export const MuiSelectDefaultProps = {
 
 export const MuiSelectStylesOverrides = {
   root: {
-    color: ({ value }) =>
-      value === '' ? palette.text.onLightLowContrast : palette.text.onLight,
+    color: ({ value, defaultValue }) =>
+      value || defaultValue
+        ? palette.text.onLight
+        : palette.text.onLightLowContrast,
   },
   select: {
     borderRadius: 8,

--- a/libs/spark/src/TextField.ts
+++ b/libs/spark/src/TextField.ts
@@ -1,0 +1,1 @@
+export const MuiTextFieldStyleOverrides = {};

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -6,6 +6,7 @@ import { MuiCheckboxStyleOverrides } from '../Checkbox';
 import { MuiFormControlLabelStyleOverrides } from '../FormControlLabel';
 import { MuiFormHelperTextStyleOverrides } from '../FormHelperText';
 import { MuiFormLabelStyleOverrides } from '../FormLabel';
+import { MuiInputStyleOverrides } from '../Input';
 import { MuiInputBaseStyleOverrides } from '../InputBase';
 import { MuiInputLabelStyleOverrides } from '../InputLabel';
 import { MuiMenuStyleOverrides } from '../Menu';
@@ -13,9 +14,9 @@ import { MuiMenuItemStyleOverrides } from '../MenuItem';
 import { MuiPaginationStyleOverrides } from '../Pagination';
 import { MuiPaginationItemStyleOverrides } from '../PaginationItem';
 import { MuiRadioStyleOverrides } from '../Radio';
+import { MuiSelectStylesOverrides } from '../Select';
 import { MuiSvgIconStyleOverrides } from '../SvgIcon';
 import { fontFaces, typography } from './typography';
-import { MuiSelectStylesOverrides } from '../Select';
 
 export const overrides = {
   MuiButtonBase: MuiButtonBaseStyleOverrides,
@@ -35,6 +36,7 @@ export const overrides = {
   MuiFormControlLabel: MuiFormControlLabelStyleOverrides,
   MuiFormHelperText: MuiFormHelperTextStyleOverrides,
   MuiFormLabel: MuiFormLabelStyleOverrides,
+  MuiInput: MuiInputStyleOverrides,
   MuiInputBase: MuiInputBaseStyleOverrides,
   MuiInputLabel: MuiInputLabelStyleOverrides,
   MuiMenu: MuiMenuStyleOverrides,

--- a/libs/spark/src/styles/props.ts
+++ b/libs/spark/src/styles/props.ts
@@ -2,6 +2,7 @@ import { MuiButtonBaseDefaultProps } from '../ButtonBase';
 import { MuiCardDefaultProps } from '../Card';
 import { MuiCheckboxDefaultProps } from '../Checkbox';
 import { MuiInputDefaultProps } from '../Input';
+import { MuiInputLabelDefaultProps } from '../InputLabel';
 import { MuiMenuDefaultProps } from '../Menu';
 import { MuiPaginationDefaultProps } from '../Pagination';
 import { MuiPaginationItemDefaultProps } from '../PaginationItem';
@@ -14,6 +15,7 @@ export const props = {
   MuiCard: MuiCardDefaultProps,
   MuiCheckbox: MuiCheckboxDefaultProps,
   MuiInput: MuiInputDefaultProps,
+  MuiInputLabel: MuiInputLabelDefaultProps,
   MuiMenu: MuiMenuDefaultProps,
   MuiPagination: MuiPaginationDefaultProps,
   MuiPaginationItem: MuiPaginationItemDefaultProps,

--- a/libs/spark/stories/select.stories.tsx
+++ b/libs/spark/stories/select.stories.tsx
@@ -17,7 +17,6 @@ export default {
   },
   args: {
     value: '',
-    displayEmpty: true,
   },
 } as Meta;
 

--- a/libs/spark/stories/text-field.stories.tsx
+++ b/libs/spark/stories/text-field.stories.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react';
+import { Story } from '@storybook/react';
+import { Meta } from '@storybook/react/types-6-0';
+import { TextField, styled, MenuItem } from '@material-ui/core';
+
+export default {
+  title: 'prenda-spark/TextField',
+  component: TextField,
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    helperText: { control: 'text' },
+    defaultValue: { control: 'text' },
+    value: { control: 'text' },
+    error: { control: 'boolean' },
+    success: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    select: { control: 'boolean' },
+    multiline: { control: 'boolean' },
+    rows: { control: 'number' },
+    rowsMax: { control: 'number' },
+    fullWidth: { control: 'boolean' },
+  },
+  args: {
+    label: 'Label',
+    placeholder: 'Placeholder',
+    helperText: 'Helper text',
+  },
+} as Meta;
+
+const Template: Story = (args) => <TextField {...args} />;
+
+export const Configurable = Template.bind({});
+
+const OuterGroup = styled('span')({
+  display: 'flex',
+  flexDirection: 'column',
+  flexWrap: 'wrap',
+  gap: '1rem',
+  margin: '1rem',
+});
+
+const InnerGroup = styled('span')({
+  display: 'flex',
+  alignItems: 'flex-start',
+  flexWrap: 'wrap',
+  gap: '1rem',
+});
+
+const StatesTemplate: Story = ({ pseudo, ...args }) => (
+  <OuterGroup>
+    <InnerGroup>
+      <TextField {...args} />
+      <TextField value="Value" {...args} />
+    </InnerGroup>
+    <InnerGroup>
+      <TextField multiline rows={3} {...args} />
+      <TextField multiline rows={3} value="Value" {...args} />
+    </InnerGroup>
+    <InnerGroup>
+      <TextField select value="" {...args}>
+        <MenuItem value="" disabled>
+          Placeholder
+        </MenuItem>
+        <MenuItem value="value">Option</MenuItem>
+        <MenuItem value="valueB">Option B</MenuItem>
+        <MenuItem value="valueC">Option C</MenuItem>
+      </TextField>
+      <TextField select value="value" {...args}>
+        <MenuItem value="" disabled>
+          Placeholder
+        </MenuItem>
+        <MenuItem value="value">Option</MenuItem>
+        <MenuItem value="valueB">Option B</MenuItem>
+        <MenuItem value="valueC">Option C</MenuItem>
+      </TextField>
+    </InnerGroup>
+    <InnerGroup>
+      <TextField className="Spark-success" {...args} />
+      <TextField className="Spark-success" value="Value" {...args} />
+    </InnerGroup>
+    <InnerGroup>
+      <TextField multiline rows={3} className="Spark-success" {...args} />
+      <TextField
+        multiline
+        rows={3}
+        className="Spark-success"
+        value="Value"
+        {...args}
+      />
+    </InnerGroup>
+    <InnerGroup>
+      <TextField select value="" className="Spark-success" {...args}>
+        <MenuItem value="" disabled>
+          Placeholder
+        </MenuItem>
+        <MenuItem value="value">Option</MenuItem>
+        <MenuItem value="valueB">Option B</MenuItem>
+        <MenuItem value="valueC">Option C</MenuItem>
+      </TextField>
+      <TextField select value="value" className="Spark-success" {...args}>
+        <MenuItem value="" disabled>
+          Placeholder
+        </MenuItem>
+        <MenuItem value="value">Option</MenuItem>
+        <MenuItem value="valueB">Option B</MenuItem>
+        <MenuItem value="valueC">Option C</MenuItem>
+      </TextField>
+    </InnerGroup>
+    <InnerGroup>
+      <TextField error {...args} />
+      <TextField error value="Value" {...args} />
+    </InnerGroup>
+    <InnerGroup>
+      <TextField multiline rows={3} error {...args} />
+      <TextField multiline rows={3} error value="Value" {...args} />
+    </InnerGroup>
+    <InnerGroup>
+      <TextField select value="" error {...args}>
+        <MenuItem value="" disabled>
+          Placeholder
+        </MenuItem>
+        <MenuItem value="value">Option</MenuItem>
+        <MenuItem value="valueB">Option B</MenuItem>
+        <MenuItem value="valueC">Option C</MenuItem>
+      </TextField>
+      <TextField select value="value" error {...args}>
+        <MenuItem value="" disabled>
+          Placeholder
+        </MenuItem>
+        <MenuItem value="value">Option</MenuItem>
+        <MenuItem value="valueB">Option B</MenuItem>
+        <MenuItem value="valueC">Option C</MenuItem>
+      </TextField>
+    </InnerGroup>
+    {pseudo ? null : (
+      <>
+        <InnerGroup>
+          <TextField disabled {...args} />
+          <TextField disabled value="Value" {...args} />
+        </InnerGroup>
+        <InnerGroup>
+          <TextField multiline rows={3} disabled {...args} />
+          <TextField multiline rows={3} disabled value="Value" {...args} />
+        </InnerGroup>
+        <InnerGroup>
+          <TextField select value="" disabled {...args}>
+            <MenuItem value="" disabled>
+              Placeholder
+            </MenuItem>
+            <MenuItem value="value">Option</MenuItem>
+            <MenuItem value="valueB">Option B</MenuItem>
+            <MenuItem value="valueC">Option C</MenuItem>
+          </TextField>
+          <TextField select value="value" disabled {...args}>
+            <MenuItem value="" disabled>
+              Placeholder
+            </MenuItem>
+            <MenuItem value="value">Option</MenuItem>
+            <MenuItem value="valueB">Option B</MenuItem>
+            <MenuItem value="valueC">Option C</MenuItem>
+          </TextField>
+        </InnerGroup>
+      </>
+    )}
+  </OuterGroup>
+);
+
+export const States = StatesTemplate.bind({});
+
+export const StatesFocus = StatesTemplate.bind({});
+StatesFocus.args = { pseudo: true };
+StatesFocus.parameters = { pseudo: { focus: true } };


### PR DESCRIPTION
Closes #100 

Modifies existing overrides to work in the context of `TextField`. This component is meant as the catch-all combination for `FormLabel, InputLabel, FormHelperText, Input, Select`.

The only failing I had was the `disabled` styling of the Placeholder `TextField select`. The font color is not as light as it should be. But due to the same issues I had in Select's introduction, targeting when the input value is an empty string (i.e. displays the placeholder), I couldn't decrease the opacity or change the font color specifically when disabled -- a dynamic rule didnt work under `{ root: { '&#disabled': { color: (props) => res } } }`.

But it's small and acceptable.