### PR TITLE
chore(ci): reduce chromatic workflow runs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,14 @@
 name: 'Chromatic'
 
-on: [push, workflow_dispatch]
+on:  
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   chromatic-deployment:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v1


### PR DESCRIPTION
We're close to our snapshot limit as a Free org in chromatic (4500 out of 5000). Chromatic provided default config runs on every push, but our workflow only requires it to run on reviewable PR's and their updates. I implemented an attempt at the goal, which I researched [here](https://github.community/t/dont-run-actions-on-draft-pull-requests/16817).