### PR TITLE
chore(spark): internalize icons

### DIFF
--- a/libs/spark/package.json
+++ b/libs/spark/package.json
@@ -4,13 +4,12 @@
   "author": "Prenda",
   "license": "MIT",
   "dependencies": {
-    "clsx": "^1.1.1",
-    "styled-components": "5.2.1"
+    "clsx": "^1.1.1"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.0.0",
     "react": "^16.8.0 || ^17.0.0",
-    "@prenda/spark-icons": "^0.0.1",
+    "styled-components": "5.2.1",
+    "@material-ui/core": "^4.0.0",
     "@material-ui/lab": "^4.0.0"
   }
 }

--- a/libs/spark/src/Select.ts
+++ b/libs/spark/src/Select.ts
@@ -1,4 +1,4 @@
-import ChevronDownIcon from '@prenda/spark-icons/ChevronDown';
+import ChevronDownIcon from './internal/ChevronDown';
 import { palette } from './styles/palette';
 
 export const MuiSelectDefaultProps = {

--- a/libs/spark/src/internal/ChevronDown.tsx
+++ b/libs/spark/src/internal/ChevronDown.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import createSvgIcon from '../utils/createSvgIcon';
+
+export default createSvgIcon(
+  <path
+    fillRule="evenodd"
+    d="M5.4697 8.4697a.75.75 0 0 1 1.0606 0L12 13.9393l5.4697-5.4696a.75.75 0 0 1 1.0606 1.0607l-6 5.9999a.75.75 0 0 1-1.0606 0l-6-6a.75.75 0 0 1 0-1.0606z"
+  />,
+  'ChevronDown'
+);

--- a/libs/spark/src/utils/createSvgIcon.tsx
+++ b/libs/spark/src/utils/createSvgIcon.tsx
@@ -1,0 +1,39 @@
+// Original credit to https://github.com/mui-org/material-ui/blob/1c5beec4be20eae30e75c69ab513bbfec3e9baaf/packages/material-ui/src/utils/createSvgIcon.js
+//  Changes made since
+
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+import { SvgIconProps as MuiSvgIconProps } from '@material-ui/core';
+
+export default function createSvgIcon(
+  path: React.ReactNode,
+  displayName: string,
+  viewBox?: string,
+  width?: string,
+  height?: string
+): typeof SvgIcon {
+  const Component = (
+    props: MuiSvgIconProps,
+    ref: React.ForwardedRef<SVGSVGElement>
+  ) => (
+    <SvgIcon
+      ref={ref}
+      viewBox={viewBox}
+      width={width}
+      height={height}
+      {...props}
+    >
+      {path}
+    </SvgIcon>
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    // Need to set `displayName` on the inner component for React.memo.
+    // React prior to 16.14 ignores `displayName` on the wrapper.
+    Component.displayName = `${displayName}Icon`;
+  }
+
+  Component.muiName = 'SvgIcon';
+
+  return React.memo(React.forwardRef(Component)) as typeof SvgIcon;
+}

--- a/workspace.json
+++ b/workspace.json
@@ -29,7 +29,8 @@
               "react-dom",
               "react-is",
               "styled-components",
-              "@material-ui"
+              "@material-ui/core",
+              "@material-ui/lab"
             ],
             "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
             "assets": [
@@ -156,7 +157,7 @@
               "react",
               "react-dom",
               "react-is",
-              "@material-ui",
+              "@material-ui/core",
               "react/jsx-runtime"
             ],
             "rollupConfig": "@nrwl/react/plugins/bundle-rollup",


### PR DESCRIPTION
Closes #161 

Internalizes the single icon from `@prenda/spark-icons` that's used by `@prenda/spark`. Thus we can eliminate the peerDep. Benefit of Nx not requiring us to build Spark Icons before Spark.

The second commit also fixes mismatches between externals and peerDeps.