### PR TITLE
feat(ListItem): transfer disabled class style overrides from MenuItem

### DIFF
--- a/libs/spark/src/ListItem.ts
+++ b/libs/spark/src/ListItem.ts
@@ -1,0 +1,9 @@
+import { palette } from './styles/palette';
+
+export const MuiListItemStyleOverrides = {
+  root: {
+    '&$disabled': {
+      color: palette.grey.dark,
+    },
+  },
+};

--- a/libs/spark/src/MenuItem.tsx
+++ b/libs/spark/src/MenuItem.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { MenuItem, MenuItemProps as MuiMenuItemProps } from '@material-ui/core';
 import { palette } from './styles/palette';
-export interface MenuItemProps extends MuiMenuItemProps {
-  startIcon?: React.ReactNode;
-  // Fix mismatch on Mui's end
-  button?: true | undefined;
-}
 
 export const MuiMenuItemStyleOverrides = {
   root: {
@@ -37,9 +32,6 @@ export const MuiMenuItemStyleOverrides = {
         color: palette.text.onLight,
       },
     },
-    '&$disabled': {
-      color: palette.grey.dark,
-    },
 
     '.SparkMenuItem-startIcon': {
       display: 'inherit',
@@ -48,6 +40,12 @@ export const MuiMenuItemStyleOverrides = {
     },
   },
 };
+
+export interface MenuItemProps extends MuiMenuItemProps {
+  startIcon?: React.ReactNode;
+  // Fix mismatch on Mui's end
+  button?: true | undefined;
+}
 
 const SparkMenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>(
   ({ startIcon, children, ...other }, ref) => {

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -17,6 +17,7 @@ import { MuiRadioStyleOverrides } from '../Radio';
 import { MuiSelectStylesOverrides } from '../Select';
 import { MuiSvgIconStyleOverrides } from '../SvgIcon';
 import { fontFaces, typography } from './typography';
+import { MuiListItemStyleOverrides } from '../ListItem';
 
 export const overrides = {
   MuiButton: MuiButtonStyleOverrides,
@@ -39,6 +40,7 @@ export const overrides = {
   MuiInput: MuiInputStyleOverrides,
   MuiInputBase: MuiInputBaseStyleOverrides,
   MuiInputLabel: MuiInputLabelStyleOverrides,
+  MuiListItem: MuiListItemStyleOverrides,
   MuiMenu: MuiMenuStyleOverrides,
   MuiMenuItem: MuiMenuItemStyleOverrides,
   MuiPagination: MuiPaginationStyleOverrides,


### PR DESCRIPTION
There were some warning that appeared whenever the spark test suite ran. The disabled class isn't defined for MenuItem, but ListItem -- which MenuItem extends.