### PR TITLE
chore(gha): add steps to publish @prenda/spark-icons

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,3 +43,32 @@ jobs:
           MSG_MINIMAL: true
           SLACK_TITLE: '@prenda/spark'
           SLACK_MESSAGE: Failure
+      - run: npm run build:icons
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./dist/libs/spark-icons-alt/package.json
+      - name: Slack Notification Success
+        if: success()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: spark-development
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_ICON: https://github.com/prenda-school/prenda-spark/raw/main/public/img/spark-logo-multicolor-darker.svg
+          SLACK_USERNAME: 'Action: NPM Publish'
+          MSG_MINIMAL: true
+          SLACK_TITLE: '@prenda/spark-icons'
+          SLACK_MESSAGE: Success
+      - name: Slack Notification Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: spark-development
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_ICON: https://github.com/prenda-school/prenda-spark/raw/main/public/img/spark-logo-multicolor-darker.svg
+          SLACK_USERNAME: 'Action: NPM Publish'
+          MSG_MINIMAL: true
+          SLACK_TITLE: '@prenda/spark-icons'
+          SLACK_MESSAGE: Failure


### PR DESCRIPTION
We should be able to use the same "automation" token that's currently setup.

Builds using the custom babel config.

Notifies the slack channel separately from `@prenda/spark` publish. Maybe another reason to create a "webhooks" channel.