### PR TITLE
chore: remove Mui re-export

### DIFF
--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -1,7 +1,3 @@
-export * from '@material-ui/core';
-// Have to be specific here, /core and /lab have overlapping exports.
-//  This is a fine reality though, /lab has few necessary component exports.
-export { Pagination, PaginationItem } from '@material-ui/lab';
 export {
   DropdownContext,
   DropdownButton,

--- a/libs/spark/stories/button.stories.tsx
+++ b/libs/spark/stories/button.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { ChevronDown } from '@prenda/spark-icons';
-import { Button, Box } from '../src';
+import { Button, Box } from '@material-ui/core';
 
 export default {
   title: 'prenda-spark/Button',

--- a/libs/spark/stories/card.stories.tsx
+++ b/libs/spark/stories/card.stories.tsx
@@ -7,11 +7,10 @@ import {
   CardMedia,
   CardActions,
   Button,
-  IconButton,
-  Typography,
   styled,
   withStyles,
-} from '../src';
+} from '@material-ui/core';
+import { IconButton, Typography } from '../src';
 
 export default {
   title: 'prenda-spark/Card',

--- a/libs/spark/stories/checkbox-group.stories.tsx
+++ b/libs/spark/stories/checkbox-group.stories.tsx
@@ -8,7 +8,7 @@ import {
   FormHelperText,
   FormGroup,
   Box,
-} from '../src';
+} from '@material-ui/core';
 
 export default {
   title: 'prenda-spark/Checkbox Group',

--- a/libs/spark/stories/checkbox.stories.tsx
+++ b/libs/spark/stories/checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { Checkbox, FormControlLabel } from '../src';
+import { Checkbox, FormControlLabel } from '@material-ui/core';
 
 export default {
   title: 'prenda-spark/Checkbox',

--- a/libs/spark/stories/colors.stories.tsx
+++ b/libs/spark/stories/colors.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
-import { useTheme, styled } from '../src';
+import { useTheme, styled } from '@material-ui/core';
 
 interface ColorBoxProps {
   color: string;

--- a/libs/spark/stories/dropdown.stories.tsx
+++ b/libs/spark/stories/dropdown.stories.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { UserDuotone, ChevronDown } from '@prenda/spark-icons';
+import { Box } from '@material-ui/core';
 import {
   DropdownContext,
   DropdownButton,
   DropdownMenu,
   DropdownMenuItem,
   DropdownDivider,
-  Box,
 } from '../src';
 
 export default {

--- a/libs/spark/stories/icon-button.stories.tsx
+++ b/libs/spark/stories/icon-button.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { ChevronDown } from '@prenda/spark-icons';
-import { IconButton, IconButtonProps, Box } from '../src';
+import { Box } from '@material-ui/core';
+import { IconButton, IconButtonProps } from '../src';
 
 export default {
   title: 'prenda-spark/IconButton',

--- a/libs/spark/stories/illustrations.stories.tsx
+++ b/libs/spark/stories/illustrations.stories.tsx
@@ -6,7 +6,7 @@ import {
   ConquerIllustration,
   CreateIllustration,
 } from '@prenda/spark-icons';
-import { styled } from '../src';
+import { styled } from '@material-ui/core';
 
 export default {
   title: 'prenda-spark/Illustrations',

--- a/libs/spark/stories/input.stories.tsx
+++ b/libs/spark/stories/input.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { Input, styled } from '../src';
+import { Input, styled } from '@material-ui/core';
 
 export default {
   title: 'prenda-spark/Input',

--- a/libs/spark/stories/logos.stories.tsx
+++ b/libs/spark/stories/logos.stories.tsx
@@ -5,7 +5,7 @@ import {
   PrendaMonogram,
   SparkMonogram,
 } from '@prenda/spark-icons';
-import { styled } from '../src';
+import { styled } from '@material-ui/core';
 
 export default {
   title: 'prenda-spark/Logos',

--- a/libs/spark/stories/navbar.stories.tsx
+++ b/libs/spark/stories/navbar.stories.tsx
@@ -9,14 +9,8 @@ import {
   UsersDuotone,
   PrendaMonogram,
 } from '@prenda/spark-icons';
-import {
-  NavBar,
-  NavBarProps,
-  NavBarButton,
-  withStyles,
-  Toolbar,
-  styled,
-} from '../src';
+import { withStyles, Toolbar, styled } from '@material-ui/core';
+import { NavBar, NavBarProps, NavBarButton } from '../src';
 
 export default {
   title: 'prenda-spark/NavBar',

--- a/libs/spark/stories/navbarbutton.stories.tsx
+++ b/libs/spark/stories/navbarbutton.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { CheckCircleDuotone } from '@prenda/spark-icons';
-import { NavBarButton, Box, NavBarButtonProps } from '../src';
+import { Box } from '@material-ui/core';
+import { NavBarButton, NavBarButtonProps } from '../src';
 
 export default {
   title: 'prenda-spark/NavBarButton',

--- a/libs/spark/stories/pagination-item.stories.tsx
+++ b/libs/spark/stories/pagination-item.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { PaginationItem } from '../src';
+import { PaginationItem } from '@material-ui/lab';
 
 export default {
   title: 'prenda-spark/Pagination Item',

--- a/libs/spark/stories/pagination.stories.tsx
+++ b/libs/spark/stories/pagination.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
-import { Pagination } from '../src';
+import { Pagination } from '@material-ui/lab';
 
 export default {
   title: 'prenda-spark/Pagination',

--- a/libs/spark/stories/radio-group.stories.tsx
+++ b/libs/spark/stories/radio-group.stories.tsx
@@ -7,7 +7,7 @@ import {
   FormControlLabel,
   Radio,
   FormHelperText,
-} from '../src';
+} from '@material-ui/core';
 
 export default {
   title: 'prenda-spark/RadioGroup',

--- a/libs/spark/stories/radio.stories.tsx
+++ b/libs/spark/stories/radio.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { FormControlLabel, Radio } from '../src';
+import { FormControlLabel, Radio } from '@material-ui/core';
 
 export default {
   title: 'prenda-spark/Radio',

--- a/libs/spark/stories/select.stories.tsx
+++ b/libs/spark/stories/select.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { Select, styled, MenuItem } from '../src';
+import { Select, styled } from '@material-ui/core';
+import { MenuItem } from '../src';
 
 export default {
   title: 'prenda-spark/Select',

--- a/libs/spark/stories/svg-icon.stories.tsx
+++ b/libs/spark/stories/svg-icon.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { styled, SvgIcon, theme } from '../src';
+import { styled } from '@material-ui/core';
+import { SvgIcon, theme } from '../src';
 import {
   AlertCircle,
   AlertCircleFilled,

--- a/libs/spark/stories/text-field.stories.tsx
+++ b/libs/spark/stories/text-field.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { TextField, styled, MenuItem } from '../src';
+import { TextField, styled } from '@material-ui/core';
+import { MenuItem } from '../src';
 
 export default {
   title: 'prenda-spark/TextField',

--- a/libs/spark/stories/typography.stories.tsx
+++ b/libs/spark/stories/typography.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { Typography, TypographyProps, styled } from '../src';
+import { styled } from '@material-ui/core';
+import { Typography, TypographyProps } from '../src';
 
 export default {
   title: 'prenda-spark/Typography',


### PR DESCRIPTION
Resolves #178 by removing the Material UI exports completely (and changing Storybook imports to match)