### PR TITLE
fix!: replace wildcard re-export of Mui with limited, named re-exports

### DIFF
--- a/libs/spark/src/Box.ts
+++ b/libs/spark/src/Box.ts
@@ -1,0 +1,1 @@
+export { Box } from '@material-ui/core';

--- a/libs/spark/src/Button.ts
+++ b/libs/spark/src/Button.ts
@@ -1,5 +1,7 @@
 import { palette } from './styles/palette';
 
+export { Button } from '@material-ui/core';
+
 export const MuiButtonDefaultProps = {
   // No disableElevation: true because it makes styling box-shadow's
   //  VERY difficult. Instead, just override wherever it pops up.

--- a/libs/spark/src/ButtonBase.ts
+++ b/libs/spark/src/ButtonBase.ts
@@ -1,3 +1,5 @@
+export { ButtonBase } from '@material-ui/core';
+
 export const MuiButtonBaseDefaultProps = {
   disableRipple: true,
   disableTouchRipple: true,

--- a/libs/spark/src/Card.tsx
+++ b/libs/spark/src/Card.tsx
@@ -1,3 +1,5 @@
+export { Card } from '@material-ui/core';
+
 export const MuiCardDefaultProps = {
   elevation: 4,
 };

--- a/libs/spark/src/CardActions.tsx
+++ b/libs/spark/src/CardActions.tsx
@@ -1,3 +1,5 @@
+export { CardActions } from '@material-ui/core';
+
 export const MuiCardActionsStyleOverrides = {
   root: {
     padding: 24,

--- a/libs/spark/src/CardContent.tsx
+++ b/libs/spark/src/CardContent.tsx
@@ -1,3 +1,5 @@
+export { CardContent } from '@material-ui/core';
+
 export const MuiCardContentStyleOverrides = {
   root: {
     padding: '24px 24px 0',

--- a/libs/spark/src/CardMedia.ts
+++ b/libs/spark/src/CardMedia.ts
@@ -1,0 +1,1 @@
+export { CardMedia } from '@material-ui/core';

--- a/libs/spark/src/Checkbox.tsx
+++ b/libs/spark/src/Checkbox.tsx
@@ -3,6 +3,8 @@ import { createSvgIcon, Theme, styled } from '@material-ui/core';
 import clsx from 'clsx';
 import { palette } from './styles/palette';
 
+export { Checkbox } from '@material-ui/core';
+
 // Recreation of Material-UI's internal RadioButton component, but
 //  with our icons(bit larger at 22x22, no empty border space)
 const SparkCheckboxIconRoot = styled('span')(

--- a/libs/spark/src/FormControl.ts
+++ b/libs/spark/src/FormControl.ts
@@ -1,0 +1,1 @@
+export { FormControl } from '@material-ui/core';

--- a/libs/spark/src/FormControlLabel.ts
+++ b/libs/spark/src/FormControlLabel.ts
@@ -1,4 +1,7 @@
 import { palette } from './styles/palette';
+
+export { FormControlLabel } from '@material-ui/core';
+
 export const MuiFormControlLabelStyleOverrides = {
   root: {
     marginLeft: -8,

--- a/libs/spark/src/FormGroup.ts
+++ b/libs/spark/src/FormGroup.ts
@@ -1,0 +1,1 @@
+export { FormGroup } from '@material-ui/core';

--- a/libs/spark/src/FormHelperText.ts
+++ b/libs/spark/src/FormHelperText.ts
@@ -1,5 +1,7 @@
 import { palette } from './styles/palette';
 
+export { FormHelperText } from '@material-ui/core';
+
 export const MuiFormHelperTextStyleOverrides = {
   root: {
     color: palette.text.onLightLowContrast,

--- a/libs/spark/src/FormLabel.ts
+++ b/libs/spark/src/FormLabel.ts
@@ -1,5 +1,7 @@
 import { palette } from './styles/palette';
 
+export { FormLabel } from '@material-ui/core';
+
 export const MuiFormLabelStyleOverrides = {
   root: {
     fontSize: '1rem',

--- a/libs/spark/src/Input.tsx
+++ b/libs/spark/src/Input.tsx
@@ -1,3 +1,5 @@
+export { Input } from '@material-ui/core';
+
 export const MuiInputDefaultProps = {
   disableUnderline: true,
 };

--- a/libs/spark/src/InputBase.tsx
+++ b/libs/spark/src/InputBase.tsx
@@ -1,5 +1,7 @@
 import { palette } from './styles/palette';
 
+export { InputBase } from '@material-ui/core';
+
 export const MuiInputBaseStyleOverrides = {
   root: {
     boxSizing: 'border-box' as const,

--- a/libs/spark/src/InputLabel.ts
+++ b/libs/spark/src/InputLabel.ts
@@ -1,5 +1,7 @@
 import { palette } from './styles/palette';
 
+export { InputLabel } from '@material-ui/core';
+
 export const MuiInputLabelDefaultProps = {
   disableAnimation: true,
 };

--- a/libs/spark/src/ListItem.ts
+++ b/libs/spark/src/ListItem.ts
@@ -1,5 +1,7 @@
 import { palette } from './styles/palette';
 
+export { ListItem } from '@material-ui/core';
+
 export const MuiListItemStyleOverrides = {
   root: {
     '&$disabled': {

--- a/libs/spark/src/Menu.ts
+++ b/libs/spark/src/Menu.ts
@@ -1,5 +1,7 @@
 import { palette } from './styles/palette';
 
+export { Menu } from '@material-ui/core';
+
 export const MuiMenuDefaultProps = {
   elevation: 3,
 };

--- a/libs/spark/src/Pagination.ts
+++ b/libs/spark/src/Pagination.ts
@@ -1,3 +1,5 @@
+export { Pagination } from '@material-ui/lab';
+
 export const MuiPaginationStyleOverrides = {
   ul: {
     // TODO: Mui-v5 move to .MuiPaginationItem-previousNext / firstLast

--- a/libs/spark/src/PaginationItem.ts
+++ b/libs/spark/src/PaginationItem.ts
@@ -1,5 +1,7 @@
 import { palette } from './styles/palette';
 
+export { PaginationItem } from '@material-ui/lab';
+
 export const MuiPaginationItemStyleOverrides = {
   root: {
     margin: 0,

--- a/libs/spark/src/Radio.tsx
+++ b/libs/spark/src/Radio.tsx
@@ -4,6 +4,8 @@ import clsx from 'clsx';
 import { palette } from './styles/palette';
 import { Theme } from '@material-ui/core';
 
+export { Radio } from '@material-ui/core';
+
 // Recreation of Material-UI's internal RadioButton component,
 //  but with our icons (bit larger at 26x26, no empty border space)
 const SparkRadioIconRoot = styled('span')(

--- a/libs/spark/src/RadioGroup.ts
+++ b/libs/spark/src/RadioGroup.ts
@@ -1,0 +1,1 @@
+export { RadioGroup } from '@material-ui/core';

--- a/libs/spark/src/Select.ts
+++ b/libs/spark/src/Select.ts
@@ -1,6 +1,8 @@
 import ChevronDownIcon from './internal/ChevronDown';
 import { palette } from './styles/palette';
 
+export { Select } from '@material-ui/core';
+
 export const MuiSelectDefaultProps = {
   displayEmpty: true,
   IconComponent: ChevronDownIcon,

--- a/libs/spark/src/TextField.ts
+++ b/libs/spark/src/TextField.ts
@@ -1,1 +1,3 @@
+export { TextField } from '@material-ui/core';
+
 export const MuiTextFieldStyleOverrides = {};

--- a/libs/spark/src/Toolbar.ts
+++ b/libs/spark/src/Toolbar.ts
@@ -1,0 +1,1 @@
+export { Toolbar } from '@material-ui/core';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -1,17 +1,11 @@
-export {
-  Box,
-  CardMedia,
-  FormControl,
-  FormGroup,
-  styled,
-  useTheme,
-  withStyles,
-} from '@material-ui/core';
+export { styled, useTheme, withStyles, makeStyles } from '@material-ui/core';
+export { Box } from './Box';
 export { Button } from './Button';
 export { ButtonBase } from './ButtonBase';
 export { Card } from './Card';
 export { CardActions } from './CardActions';
 export { CardContent } from './CardContent';
+export { CardMedia } from './CardMedia';
 export { Checkbox } from './Checkbox';
 export {
   DropdownContext,
@@ -26,7 +20,9 @@ export type {
   DropdownMenuProps,
   DropdownMenuItemProps,
 } from './Dropdown';
+export { FormControl } from './FormControl';
 export { FormControlLabel } from './FormControlLabel';
+export { FormGroup } from './FormGroup';
 export { FormHelperText } from './FormHelperText';
 export { FormLabel } from './FormLabel';
 export { IconButton } from './IconButton';
@@ -41,11 +37,13 @@ export type { MenuItemProps } from './MenuItem';
 export { Pagination } from './Pagination';
 export { PaginationItem } from './PaginationItem';
 export { Radio } from './Radio';
+export { RadioGroup } from './RadioGroup';
 export { Select } from './Select';
 export { SparkThemeProvider } from './SparkThemeProvider';
 export { SvgIcon } from './SvgIcon';
 export type { SvgIconProps } from './SvgIcon';
 export { TextField } from './TextField';
+export { Toolbar } from './Toolbar';
 export { theme } from './styles';
 export { Typography } from './Typography';
 export type { TypographyProps } from './Typography';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -1,7 +1,18 @@
-export * from '@material-ui/core';
-// Have to be specific here, /core and /lab have overlapping exports.
-//  This is a fine reality though, /lab has few necessary component exports.
-export { Pagination, PaginationItem } from '@material-ui/lab';
+export {
+  Box,
+  CardMedia,
+  FormControl,
+  FormGroup,
+  styled,
+  useTheme,
+  withStyles,
+} from '@material-ui/core';
+export { Button } from './Button';
+export { ButtonBase } from './ButtonBase';
+export { Card } from './Card';
+export { CardActions } from './CardActions';
+export { CardContent } from './CardContent';
+export { Checkbox } from './Checkbox';
 export {
   DropdownContext,
   DropdownButton,
@@ -15,13 +26,26 @@ export type {
   DropdownMenuProps,
   DropdownMenuItemProps,
 } from './Dropdown';
+export { FormControlLabel } from './FormControlLabel';
+export { FormHelperText } from './FormHelperText';
+export { FormLabel } from './FormLabel';
 export { IconButton } from './IconButton';
 export type { IconButtonProps } from './IconButton';
+export { Input } from './Input';
+export { InputBase } from './InputBase';
+export { InputLabel } from './InputLabel';
+export { ListItem } from './ListItem';
+export { Menu } from './Menu';
 export { MenuItem } from './MenuItem';
 export type { MenuItemProps } from './MenuItem';
+export { Pagination } from './Pagination';
+export { PaginationItem } from './PaginationItem';
+export { Radio } from './Radio';
+export { Select } from './Select';
 export { SparkThemeProvider } from './SparkThemeProvider';
 export { SvgIcon } from './SvgIcon';
 export type { SvgIconProps } from './SvgIcon';
+export { TextField } from './TextField';
 export { theme } from './styles';
 export { Typography } from './Typography';
 export type { TypographyProps } from './Typography';


### PR DESCRIPTION
Resolves #178 by removing `export * from '@material-ui/core'` and replacing it with specific exports of just components the Prenda library styles or uses in Storybook examples.