### PR TITLE
feat(spark typography): match Figma font weights

### DIFF
--- a/libs/spark/README.md
+++ b/libs/spark/README.md
@@ -35,6 +35,8 @@ Now you can develop components within the `libs/spark/src/` directory and see ch
 
 Depending on your preferred IDE, consider downloading a [community IDE plugin for Nx workspaces](https://nx.dev/latest/react/getting-started/console#download).
 
+The Spark theme refers to font files for _Nunito_, which should be served at the `/fonts` path. These fonts are available in this library in `libs/spark/public/fonts`.
+
 ## Testing
 
 Run tests with `nx run spark:test`.

--- a/libs/spark/src/Typography.tsx
+++ b/libs/spark/src/Typography.tsx
@@ -14,7 +14,7 @@ const styles = (theme: Theme) =>
   createStyles({
     root: {
       '& strong, b': {
-        fontWeight: 500,
+        fontWeight: 600,
       },
     },
     initial: {}, // to satisfy TS
@@ -39,83 +39,83 @@ const styles = (theme: Theme) =>
     'display-lg': {
       fontSize: '4rem',
       lineHeight: '4rem',
-      fontWeight: 700,
+      fontWeight: 800,
     },
     'display-md': {
       fontSize: '3.5rem',
       lineHeight: '3.5rem',
-      fontWeight: 700,
+      fontWeight: 800,
     },
     'display-sm': {
       fontSize: '3rem',
       lineHeight: '3rem',
-      fontWeight: 700,
+      fontWeight: 800,
     },
     'heading-xxl': {
       fontSize: '2.5rem',
       lineHeight: '2.5rem',
-      fontWeight: 500,
+      fontWeight: 600,
     },
     'heading-xl': {
       fontSize: '2.125rem',
       lineHeight: '2.125rem',
-      fontWeight: 500,
+      fontWeight: 600,
     },
     'heading-lg': {
       fontSize: '1.75rem',
       lineHeight: '1.875rem',
-      fontWeight: 500,
+      fontWeight: 600,
     },
     'heading-md': {
       fontSize: '1.5rem',
       lineHeight: '1.625rem',
-      fontWeight: 500,
+      fontWeight: 600,
     },
     'heading-sm': {
       fontSize: '1.25rem',
       lineHeight: '1.375rem',
-      fontWeight: 500,
+      fontWeight: 600,
     },
     'smallcaps-lg': {
       fontSize: '1rem',
       lineHeight: '1rem',
       letterSpacing: '.1em',
-      fontWeight: 600,
+      fontWeight: 800,
       textTransform: 'uppercase',
     },
     'smallcaps-md': {
       fontSize: '0.875rem',
       lineHeight: '0.875rem',
       letterSpacing: '.1em',
-      fontWeight: 600,
+      fontWeight: 800,
       textTransform: 'uppercase',
     },
     'smallcaps-sm': {
       fontSize: '0.75rem',
       lineHeight: '0.75rem',
       letterSpacing: '.1em',
-      fontWeight: 600,
+      fontWeight: 800,
       textTransform: 'uppercase',
     },
     'label-xl': {
       fontSize: '1.125rem',
       lineHeight: '1.5rem',
-      fontWeight: 400,
+      fontWeight: 500,
     },
     'label-lg': {
       fontSize: '1rem',
       lineHeight: '1.5rem',
-      fontWeight: 400,
+      fontWeight: 500,
     },
     'label-md': {
       fontSize: '0.875rem',
       lineHeight: '1.25rem',
-      fontWeight: 400,
+      fontWeight: 500,
     },
     'label-sm': {
       fontSize: '0.75rem',
       lineHeight: '1.25rem',
-      fontWeight: 400,
+      fontWeight: 500,
     },
     'paragraph-xl': {
       fontSize: '1.125rem',

--- a/libs/spark/stories/typography.stories.tsx
+++ b/libs/spark/stories/typography.stories.tsx
@@ -115,8 +115,9 @@ enum Sizes {
 }
 
 enum Styles {
+  Extrabold = 'ExtraBold',
   Bold = 'Bold',
-  Semibold = 'Condensed/Semibold',
+  Semibold = 'Condensed/SemiBold',
   Medium = 'Medium',
   Regular = 'Regular',
 }
@@ -133,19 +134,19 @@ const baseMap = {
     {
       text: Sizes.Large,
       values: '64px/64px',
-      style: Styles.Bold,
+      style: Styles.Extrabold,
       variant: 'display-lg',
     } as BaseInfo,
     {
       text: Sizes.Medium,
       values: '56px/56px',
-      style: Styles.Bold,
+      style: Styles.Extrabold,
       variant: 'display-md',
     } as BaseInfo,
     {
       text: Sizes.Small,
       values: '48px/48px',
-      style: Styles.Bold,
+      style: Styles.Extrabold,
       variant: 'display-sm',
     } as BaseInfo,
   ],
@@ -153,31 +154,31 @@ const baseMap = {
     {
       text: Sizes.XXLarge,
       values: '40px/40px',
-      style: Styles.Medium,
+      style: Styles.Bold,
       variant: 'heading-xxl',
     } as BaseInfo,
     {
       text: Sizes.XLarge,
       values: '34px/34px',
-      style: Styles.Medium,
+      style: Styles.Bold,
       variant: 'heading-xl',
     } as BaseInfo,
     {
       text: Sizes.Large,
       values: '28px/30px',
-      style: Styles.Medium,
+      style: Styles.Bold,
       variant: 'heading-lg',
     } as BaseInfo,
     {
       text: Sizes.Medium,
       values: '24px/26px',
-      style: Styles.Medium,
+      style: Styles.Bold,
       variant: 'heading-md',
     } as BaseInfo,
     {
       text: Sizes.Small,
       values: '20px/22px',
-      style: Styles.Medium,
+      style: Styles.Bold,
       variant: 'heading-sm',
     } as BaseInfo,
   ],
@@ -185,19 +186,19 @@ const baseMap = {
     {
       text: Sizes.Large,
       values: '16px/16px/10%',
-      style: Styles.Semibold,
+      style: Styles.Extrabold,
       variant: 'smallcaps-lg',
     } as BaseInfo,
     {
       text: Sizes.Medium,
       values: '14px/14px/10%',
-      style: Styles.Semibold,
+      style: Styles.Extrabold,
       variant: 'smallcaps-md',
     } as BaseInfo,
     {
       text: Sizes.Small,
       values: '12px/12px/10%',
-      style: Styles.Semibold,
+      style: Styles.Extrabold,
       variant: 'smallcaps-sm',
     } as BaseInfo,
   ],
@@ -205,7 +206,7 @@ const baseMap = {
     {
       text: Sizes.XLarge,
       values: '18px/24px',
-      style: Styles.Regular,
+      style: Styles.Semibold,
       variant: 'label-xl',
     } as BaseInfo,
     {
@@ -218,7 +219,7 @@ const baseMap = {
     {
       text: Sizes.Large,
       values: '16px/24px',
-      style: Styles.Regular,
+      style: Styles.Semibold,
       variant: 'label-lg',
     } as BaseInfo,
     {
@@ -231,7 +232,7 @@ const baseMap = {
     {
       text: Sizes.Medium,
       values: '14px/20px',
-      style: Styles.Regular,
+      style: Styles.Semibold,
       variant: 'label-md',
     } as BaseInfo,
     {
@@ -244,7 +245,7 @@ const baseMap = {
     {
       text: Sizes.Small,
       values: '12px/20px',
-      style: Styles.Regular,
+      style: Styles.Semibold,
       variant: 'label-sm',
     } as BaseInfo,
     {


### PR DESCRIPTION
Update Typography font-weights and storybook to match Figma specifications [here](https://www.figma.com/file/KTeHk612CXRDK2nrOI1nei/Spark-Typography?node-id=2%3A2)

Resolves #33 