### PR TITLE
feat(theme): adjust shadows to new elevations spec

### DIFF
--- a/libs/spark/src/Card.tsx
+++ b/libs/spark/src/Card.tsx
@@ -1,8 +1,9 @@
 export { Card } from '@material-ui/core';
 
 export const MuiCardDefaultProps = {
-  elevation: 4,
+  elevation: 2, // E200
 };
+
 export const MuiCardStyleOverrides = {
   root: {
     borderRadius: 16,

--- a/libs/spark/src/Menu.ts
+++ b/libs/spark/src/Menu.ts
@@ -3,7 +3,7 @@ import { palette } from './styles/palette';
 export { Menu } from '@material-ui/core';
 
 export const MuiMenuDefaultProps = {
-  elevation: 3,
+  elevation: 4, // E400
 };
 
 export const MuiMenuStyleOverrides = {

--- a/libs/spark/src/styles/shadows.ts
+++ b/libs/spark/src/styles/shadows.ts
@@ -1,43 +1,49 @@
 import { Shadows } from '@material-ui/core/styles/shadows';
 
-const shadowKeyUmbraOpacity = 0.1;
-const shadowKeyPenumbraOpacity = 0.07;
-const shadowAmbientShadowOpacity = 0.06;
-
-function createShadow(...px) {
+/**
+ * Generate Spark Design elevation shadows, a series of two box shadows. First
+ * shadow appears like a light border. Second shadow is a "key light" shadow,
+ * adjusted to given input.
+ * @param {number} yOffset of key light shadow, in pixels.
+ * @param {number} blurRadius of key light shadow, in pixels.
+ * @param {number} transparency of key light shadow color, from 0 to 1.
+ * @returns {string} comma-separated box-shadow values.
+ */
+function createElevationShadow(yOffset, blurRadius, transparency) {
   return [
-    `${px[0]}px ${px[1]}px ${px[2]}px ${px[3]}px rgba(0, 0, 0, ${shadowKeyUmbraOpacity})`,
-    `${px[4]}px ${px[5]}px ${px[6]}px ${px[7]}px rgba(0, 0, 0, ${shadowKeyPenumbraOpacity})`,
-    `${px[8]}px ${px[9]}px ${px[10]}px ${px[11]}px rgba(0, 0, 0, ${shadowAmbientShadowOpacity})`,
+    '0 0 1px 0 rgba(7, 46, 68, 0.31)',
+    `0 ${yOffset} ${blurRadius} rgba(7, 46, 68, ${transparency})`,
   ].join(',');
 }
 
+const highestElevationShadow = createElevationShadow(18, 28, 0.15);
+
 const shadows: Shadows = [
   'none',
-  createShadow(0, 1, 3, 0, 0, 1, 1, 0, 0, 2, 1, -1),
-  createShadow(0, 1, 5, 0, 0, 2, 2, 0, 0, 3, 1, -2),
-  createShadow(0, 1, 8, 0, 0, 3, 4, 0, 0, 3, 3, -2),
-  createShadow(0, 2, 4, -1, 0, 4, 5, 0, 0, 1, 10, 0),
-  createShadow(0, 3, 5, -1, 0, 5, 8, 0, 0, 1, 14, 0),
-  createShadow(0, 3, 5, -1, 0, 6, 10, 0, 0, 1, 18, 0),
-  createShadow(0, 4, 5, -2, 0, 7, 10, 1, 0, 2, 16, 1),
-  createShadow(0, 5, 5, -3, 0, 8, 10, 1, 0, 3, 14, 2),
-  createShadow(0, 5, 6, -3, 0, 9, 12, 1, 0, 3, 16, 2),
-  createShadow(0, 6, 6, -3, 0, 10, 14, 1, 0, 4, 18, 3),
-  createShadow(0, 6, 7, -4, 0, 11, 15, 1, 0, 4, 20, 3),
-  createShadow(0, 7, 8, -4, 0, 12, 17, 2, 0, 5, 22, 4),
-  createShadow(0, 7, 8, -4, 0, 13, 19, 2, 0, 5, 24, 4),
-  createShadow(0, 7, 9, -4, 0, 14, 21, 2, 0, 5, 26, 4),
-  createShadow(0, 8, 9, -5, 0, 15, 22, 2, 0, 6, 28, 5),
-  createShadow(0, 8, 10, -5, 0, 16, 24, 2, 0, 6, 30, 5),
-  createShadow(0, 8, 11, -5, 0, 17, 26, 2, 0, 6, 32, 5),
-  createShadow(0, 9, 11, -5, 0, 18, 28, 2, 0, 7, 34, 6),
-  createShadow(0, 9, 12, -6, 0, 19, 29, 2, 0, 7, 36, 6),
-  createShadow(0, 10, 13, -6, 0, 20, 31, 3, 0, 8, 38, 7),
-  createShadow(0, 10, 13, -6, 0, 21, 33, 3, 0, 8, 40, 7),
-  createShadow(0, 10, 14, -6, 0, 22, 35, 3, 0, 8, 42, 7),
-  createShadow(0, 11, 14, -7, 0, 23, 36, 3, 0, 9, 44, 8),
-  createShadow(0, 11, 15, -7, 0, 24, 38, 3, 0, 9, 46, 8),
+  createElevationShadow(1, 1, 0.24),
+  createElevationShadow(3, 5, 0.2),
+  createElevationShadow(8, 12, 0.15),
+  createElevationShadow(10, 18, 0.15),
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
+  highestElevationShadow,
 ];
 
 export { shadows };

--- a/libs/spark/src/styles/shadows.ts
+++ b/libs/spark/src/styles/shadows.ts
@@ -20,11 +20,11 @@ const highestElevationShadow = createElevationShadow(18, 28, 0.15);
 
 const shadows: Shadows = [
   'none',
-  createElevationShadow(1, 1, 0.24),
-  createElevationShadow(3, 5, 0.2),
-  createElevationShadow(8, 12, 0.15),
-  createElevationShadow(10, 18, 0.15),
-  highestElevationShadow,
+  createElevationShadow(1, 1, 0.24), // E100
+  createElevationShadow(3, 5, 0.2), // E200
+  createElevationShadow(8, 12, 0.15), // E300
+  createElevationShadow(10, 18, 0.15), // E400
+  highestElevationShadow, // E500
   highestElevationShadow,
   highestElevationShadow,
   highestElevationShadow,

--- a/libs/spark/src/styles/shadows.ts
+++ b/libs/spark/src/styles/shadows.ts
@@ -12,8 +12,8 @@ import { Shadows } from '@material-ui/core/styles/shadows';
 function createElevationShadow(yOffset, blurRadius, transparency) {
   return [
     '0 0 1px 0 rgba(7, 46, 68, 0.31)',
-    `0 ${yOffset} ${blurRadius} rgba(7, 46, 68, ${transparency})`,
-  ].join(',');
+    `0 ${yOffset}px ${blurRadius}px rgba(7, 46, 68, ${transparency})`,
+  ].join(', ');
 }
 
 const highestElevationShadow = createElevationShadow(18, 28, 0.15);

--- a/libs/spark/stories/card.stories.tsx
+++ b/libs/spark/stories/card.stories.tsx
@@ -20,8 +20,15 @@ export default {
   args: {},
 } as Meta;
 
+const CustomCard = withStyles({
+  root: {
+    maxWidth: 400,
+    margin: 8,
+  },
+})(Card);
+
 export const BasicCard: Story = () => (
-  <Card style={{ maxWidth: 400 }}>
+  <CustomCard>
     <CardContent>
       <Typography
         variant="heading-md"
@@ -41,7 +48,7 @@ export const BasicCard: Story = () => (
         Action
       </Button>
     </CardActions>
-  </Card>
+  </CustomCard>
 );
 
 const StyledImage = styled('img')({


### PR DESCRIPTION
Translates Spark Design Elevations E100 to E500 to `theme.shadows[1 ... 5]` and sets `theme.shadows[5 ... 24]` to be equivalent to `theme.shadows[5]`, the highest elevation shadow.

Replaces Mui's utility with one that fits our exact need.

Adjusts components that use elevations (Card and Menu) to their new prescribed elevations.

Unfortunately, it was not possible to customize the shadows object to have our elevations correspond to keys like `shadows[100]` etc. This was because the `type Shadows` cannot be overridden with TS module augmentation. Other, more cruder overriding methods still couldn't satisfy dependents, like `ThemeOptions` or `Theme`, to play well with a custom type.