### PR TITLE
feat(Avatar): initial implementation

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Features
 
+- **Avatar**
+  - Initial implementation.
 - **Typography**
   - New `color` prop values:
     - `'onLight'`

--- a/libs/spark/src/Avatar.tsx
+++ b/libs/spark/src/Avatar.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import {
+  makeStyles,
+  Theme,
+  Avatar as MuiAvatar,
+  AvatarProps as MuiAvatarProps,
+  AvatarClassKey as MuiAvatarClassKey,
+} from '@material-ui/core';
+import {
+  OverrideProps,
+  OverridableComponent,
+} from '@material-ui/core/OverridableComponent';
+import { capitalize } from './utils';
+import { palette } from './styles/palette';
+
+// TEMPORARY, REMOVE ME
+/* Full credit to https://github.com/mui-org/material-ui/blob/5cc1d0fc8756534f181d55af02a5a0d65b486603/packages/material-ui-styles/src/withStyles/withStyles.d.ts#L81 */
+export type ClassNameMap<ClassKey extends string = string> = Record<
+  ClassKey,
+  string
+>;
+
+export type AvatarClassKey = MuiAvatarClassKey | CustomClassKey;
+
+type CustomClassKey = 'sizeLarge' | 'sizeMedium' | 'sizeSmall' | 'sizeXsmall';
+
+export interface AvatarTypeMap<
+  P = Record<string, unknown>,
+  D extends React.ElementType = 'div'
+> {
+  props: P &
+    Omit<MuiAvatarProps, 'variant' | 'classes'> & {
+      /**
+       * The size of the avatar.
+       */
+      size?: 'large' | 'medium' | 'small' | 'xsmall';
+    };
+  defaultComponent: D;
+  classKey: AvatarClassKey;
+}
+
+export type AvatarProps<
+  D extends React.ElementType = AvatarTypeMap['defaultComponent'],
+  P = Record<string, unknown>
+> = OverrideProps<AvatarTypeMap<P, D>, D>;
+
+export const MuiAvatarStyleOverrides = {
+  root: {
+    border: `2px solid ${palette.grey.medium}`,
+  },
+  colorDefault: {
+    backgroundColor: palette.common.white,
+    color: palette.text.onLight,
+    '& > .MuiSvgIcon-root': {
+      color: palette.text.onLightLowContrast,
+    },
+  },
+};
+
+const useStyles = makeStyles(
+  (theme: Theme) => ({
+    // sizes have -2px from design to account for border width
+    sizeLarge: {
+      ...theme.typography['heading-lg'],
+      width: 78,
+      height: 78,
+      '& > .MuiSvgIcon-root': {
+        fontSize: theme.typography.pxToRem(40),
+      },
+    },
+    sizeMedium: {
+      ...theme.typography['heading-md'],
+      width: 54,
+      height: 54,
+      '& > .MuiSvgIcon-root': {
+        fontSize: theme.typography.pxToRem(28),
+      },
+    },
+    sizeSmall: {
+      ...theme.typography['label-md'],
+      fontWeight: 700,
+      width: 30,
+      height: 30,
+      '& > .MuiSvgIcon-root': {
+        fontSize: theme.typography.pxToRem(16),
+      },
+    },
+    sizeXsmall: {
+      width: 22,
+      height: 22,
+      fontSize: theme.typography.pxToRem(8),
+      lineHeight: 1.5,
+      fontWeight: 700,
+      '& > .MuiSvgIcon-root': {
+        fontSize: theme.typography.pxToRem(12),
+      },
+    },
+  }),
+  { name: 'SparkAvatar' }
+);
+
+export const Avatar: OverridableComponent<AvatarTypeMap> = React.forwardRef(
+  function Avatar(props, ref) {
+    const { classes: passedClasses = {}, size = 'medium', ...other } = props;
+
+    const baseCustomClasses = useStyles();
+
+    // extract custom class keys from passed classes
+    //  => produce union of customClasses and extraction
+    //     & produce intersection of passed classes and complement of custom classes
+    // TODO: once WET, extract to common utility func / hook
+    const underlyingClasses: Partial<ClassNameMap<MuiAvatarClassKey>> = {};
+    const customClasses: Partial<ClassNameMap<CustomClassKey>> = {
+      ...baseCustomClasses,
+    };
+
+    for (const [key, value] of Object.entries(passedClasses)) {
+      const customValue = customClasses[key];
+      if (customValue) {
+        customClasses[key] = `${customValue} ${value}`;
+      } else {
+        underlyingClasses[key] = value;
+      }
+    }
+
+    return (
+      <MuiAvatar
+        classes={{
+          ...underlyingClasses,
+          root: clsx(
+            underlyingClasses.root,
+            customClasses[`size${capitalize(size)}`]
+          ),
+        }}
+        {...other}
+        ref={ref}
+      />
+    );
+  }
+);

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -1,4 +1,5 @@
 export { styled, useTheme, withStyles, makeStyles } from '@material-ui/core';
+export { Avatar } from './Avatar';
 export { Box } from './Box';
 export { Button } from './Button';
 export { ButtonBase } from './ButtonBase';

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -1,3 +1,4 @@
+import { MuiAvatarStyleOverrides } from '../Avatar';
 import { MuiButtonStyleOverrides } from '../Button';
 import { MuiCardStyleOverrides } from '../Card';
 import { MuiCardContentStyleOverrides } from '../CardContent';
@@ -22,6 +23,7 @@ import { MuiTypographyStyleOverrides } from '../Typography';
 import { fontFaces, typography } from './typography';
 
 export const overrides = {
+  MuiAvatar: MuiAvatarStyleOverrides,
   MuiButton: MuiButtonStyleOverrides,
   MuiCssBaseline: {
     '@global': {

--- a/libs/spark/stories/avatar.stories.tsx
+++ b/libs/spark/stories/avatar.stories.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { UserDuotone } from '@prenda/spark-icons';
+import { Avatar, Box, Typography, withStyles } from '../src';
+
+export default {
+  title: 'prenda-spark/Avatar',
+  component: Avatar,
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['large', 'medium', 'small', 'xsmall'],
+    },
+    src: {
+      control: 'select',
+      options: [
+        '/img/guide-1.png',
+        '/img/guide-2.png',
+        '/img/guide-3.png',
+        '/img/student-boy-1.png',
+        '/img/student-boy-2.png',
+        '/img/student-boy-3.png',
+        '/img/student-girl-1.png',
+        '/img/student-girl-2.png',
+        '/img/student-girl-3.png',
+      ],
+    },
+    alt: { type: 'text' },
+  },
+  args: {
+    size: 'medium',
+    src: '/img/guide-1.png',
+    alt: 'Jane Doe',
+  },
+} as Meta;
+
+const Template = ({ src, alt, ...other }) => (
+  <Box display="flex" p={1} style={{ gap: '16px' }}>
+    <Avatar src={src} alt={alt} {...other} />
+    <Avatar {...other}>
+      <UserDuotone />
+    </Avatar>
+    <Avatar {...other}>AC</Avatar>
+  </Box>
+);
+
+export const Configurable: Story = Template.bind({});
+
+const GridContainer = (props) => (
+  <Box
+    m={1}
+    display="grid"
+    gridTemplateColumns="repeat(4, 100px)"
+    gridGap="16px"
+    alignItems="center"
+    justifyItems="center"
+    {...props}
+  />
+);
+
+const ContentAndSizeTemplate = ({ src, alt, ...other }) => (
+  <GridContainer>
+    <span>Size / Content</span>
+    <span>Image</span>
+    <span>Icon</span>
+    <span>Letter(s)</span>
+    <span>large</span>
+    <span>
+      <Avatar src={src} alt={alt} size="large" />
+    </span>
+    <span>
+      <Avatar size="large">
+        <UserDuotone />
+      </Avatar>
+    </span>
+    <span>
+      <Avatar size="large">AC</Avatar>
+    </span>
+    <span>medium</span>
+    <span>
+      <Avatar src={src} alt={alt} size="medium" />
+    </span>
+    <span>
+      <Avatar size="medium">
+        <UserDuotone />
+      </Avatar>
+    </span>
+    <span>
+      <Avatar size="medium">AC</Avatar>
+    </span>
+    <span>small</span>
+    <span>
+      <Avatar src={src} alt={alt} size="small" />
+    </span>
+    <span>
+      <Avatar size="small">
+        <UserDuotone />
+      </Avatar>
+    </span>
+    <span>
+      <Avatar size="small">AC</Avatar>
+    </span>
+    <span>xsmall</span>
+    <span>
+      <Avatar src={src} alt={alt} size="xsmall" />
+    </span>
+    <span>
+      <Avatar size="xsmall">
+        <UserDuotone />
+      </Avatar>
+    </span>
+    <span>
+      <Avatar size="xsmall">AC</Avatar>
+    </span>
+  </GridContainer>
+);
+
+export const ContentAndSize: Story = ContentAndSizeTemplate.bind({});
+
+// TODO: extract these to reusable decorator/template?
+
+const H1 = (props) => (
+  <Typography variant="heading-md" component="h1" gutterBottom {...props} />
+);
+
+const H2 = withStyles({
+  root: { marginLeft: 8 },
+})((props) => <Typography variant="heading-sm" component="h2" {...props} />);
+
+const SmCode = withStyles((theme) => ({
+  root: {
+    backgroundColor: theme.palette.background.lightGrey,
+    padding: '0 2px',
+  },
+}))((props) => <Typography variant="code-sm" display="inline" {...props} />);
+
+const Li = (props) => (
+  <Typography variant="paragraph-lg" component="li" {...props} />
+);
+
+const LiCode = (props) => (
+  <Li>
+    <SmCode {...props} />
+  </Li>
+);
+
+const DocumentationTemplate = () => (
+  <>
+    <H1>Underlying Component</H1>
+    <ul>
+      <Li>
+        Avatar,{' '}
+        <a href="https://material-ui.com/components/avatars/#avatar">
+          https://material-ui.com/components/avatars/#avatar
+        </a>
+      </Li>
+    </ul>
+    <Box m={1} />
+    <H1>API</H1>
+    <H2>Prop Names</H2>
+    <ul>
+      <Li>
+        Extends{' '}
+        <a href="https://material-ui.com/api/avatar/#props">
+          https://material-ui.com/api/avatar/#props
+        </a>
+      </Li>
+      <Li>Omits:</Li>
+      <ul>
+        <Li>
+          <SmCode>variant</SmCode>
+          <ul>
+            <Li>
+              underlying default value: <SmCode>'circular'</SmCode>
+            </Li>
+          </ul>
+        </Li>
+      </ul>
+      <Li>
+        Adds:
+        <ul>
+          <LiCode>size</LiCode>
+          <ul>
+            <Li>
+              type: <SmCode>'large' | 'medium' | 'small' | 'xsmall'</SmCode>
+            </Li>
+            <Li>
+              default: <SmCode>'medium'</SmCode>
+            </Li>
+          </ul>
+        </ul>
+      </Li>
+    </ul>
+    <H2>CSS Rule Names</H2>
+    <ul>
+      <Li>
+        Extends{' '}
+        <a href="https://material-ui.com/api/avatar/#css">
+          https://material-ui.com/api/avatar/#css
+        </a>
+      </Li>
+      <Li>
+        Adds:
+        <ul>
+          <LiCode>sizeLarge</LiCode>
+          <LiCode>sizeMedium</LiCode>
+          <LiCode>sizeSmall</LiCode>
+          <LiCode>sizeXsmall</LiCode>
+        </ul>
+      </Li>
+    </ul>
+  </>
+);
+
+export const Documentation: Story = DocumentationTemplate.bind({});
+
+const ChangelogTemplate = () => (
+  <ul>
+    <Li>
+      <SmCode>vNext (yyyy-mm-dd)</SmCode>: initial implementation
+    </Li>
+  </ul>
+);
+
+export const Changelog: Story = ChangelogTemplate.bind({});

--- a/libs/spark/stories/navbar.stories.tsx
+++ b/libs/spark/stories/navbar.stories.tsx
@@ -26,13 +26,14 @@ export default {
 } as Meta;
 
 const BluePrendaMonogram = styled(PrendaMonogram)(({ theme }) => ({
-  fontSize: '62px',
+  fontSize: '72px',
   fill: theme.palette.brand.blue,
 }));
 
 const CustomToolbar = withStyles({
   root: {
     gap: 8,
+    height: 80,
   },
 })(Toolbar);
 
@@ -44,13 +45,6 @@ const InboxNavBarButton = withStyles({
     marginRight: 2,
   },
 })(NavBarButton);
-
-const CustomAvatar = withStyles({
-  root: {
-    width: 38,
-    height: 38,
-  },
-})(Avatar);
 
 const Template: Story<NavBarProps> = (args) => (
   <NavBar {...args}>
@@ -78,7 +72,7 @@ const Template: Story<NavBarProps> = (args) => (
       >
         0
       </InboxNavBarButton>
-      <CustomAvatar src="/img/student-boy-2.png" alt="john doe" />
+      <Avatar src="/img/student-boy-2.png" alt="john doe" size="medium" />
     </CustomToolbar>
   </NavBar>
 );

--- a/libs/spark/stories/navbar.stories.tsx
+++ b/libs/spark/stories/navbar.stories.tsx
@@ -5,7 +5,6 @@ import {
   HomeDuotone,
   InboxFilledDuotone,
   MountainDuotone,
-  UserDuotone,
   UsersDuotone,
   PrendaMonogram,
 } from '@prenda/spark-icons';
@@ -16,6 +15,7 @@ import {
   withStyles,
   Toolbar,
   styled,
+  Avatar,
 } from '../src';
 
 export default {
@@ -24,11 +24,6 @@ export default {
   argTypes: {},
   args: {},
 } as Meta;
-
-const UserMenu = styled('div')({
-  display: 'flex',
-  alignItems: 'center',
-});
 
 const BluePrendaMonogram = styled(PrendaMonogram)(({ theme }) => ({
   fontSize: '62px',
@@ -49,6 +44,13 @@ const InboxNavBarButton = withStyles({
     marginRight: 2,
   },
 })(NavBarButton);
+
+const CustomAvatar = withStyles({
+  root: {
+    width: 38,
+    height: 38,
+  },
+})(Avatar);
 
 const Template: Story<NavBarProps> = (args) => (
   <NavBar {...args}>
@@ -76,9 +78,7 @@ const Template: Story<NavBarProps> = (args) => (
       >
         0
       </InboxNavBarButton>
-      <UserMenu>
-        <UserDuotone color="onLight" fontSize="large" />
-      </UserMenu>
+      <CustomAvatar src="/img/student-boy-2.png" alt="john doe" />
     </CustomToolbar>
   </NavBar>
 );


### PR DESCRIPTION
Closes #52 

- Implements a custom classes CSS API like `Typography`, that is style-able with customers using the standard utilities (`withStyles`, etc.).
  - See #200 for details
- Implements 4 sizes across 3 content types
- Content types are intentionally not variants, they have intertwining behavior, see Mui docs.
- Adds documentation story linking out to Mui and highlighting differences.
- Adds changelog story

I'm imagining both Documentation and Changelog stories to become standard for all components.