### PR TITLE
feat(MenuList): add initial support

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -25,10 +25,16 @@
 
 - **Avatar**
   - Initial implementation.
+- **Divider**
+  - Added re-export.
+  - Added minimal styling related to **MenuList** styling support.
 - **Input**
   - See **InputBase**.
 - **InputBase**
   - Added styling for `startAdornment` and `endAdornment` props.
+- **List**
+  - Added re-export.
+  - Added minimal styling related to **MenuList** styling support.
 - **ListItem**
   - Added minimal styling related to **MenuItem** styling support.
 - **ListItemAvatar**
@@ -40,10 +46,19 @@
 - **ListItemText**
   - Added re-export.
   - Added minimal styling related to **MenuItem** styling support.
+- **ListSubheader**
+  - Added re-export.
+  - Added minimal styling related to **MenuList** styling support.
 - **MenuItem**
   - Added styling for pseudo-states: `:hover`, `:focus`, `:active`
   - Added styling for content: `ListItemText`, `ListItemIcon`, `ListItemAvatar`, `ListItem`
   - Added styling when prop `selected` is `true`.
+- **MenuList**
+  - Added re-export.
+  - Confirmed styling.
+- **Paper**
+  - Added re-export.
+  - Added minimal styling related to **MenuList** styling support.
 - **Select**
   - See **InputBase**.
 - **Tag**

--- a/libs/spark/src/Divider.ts
+++ b/libs/spark/src/Divider.ts
@@ -1,0 +1,14 @@
+import { Divider } from '@material-ui/core';
+import type { DividerProps } from '@material-ui/core';
+import { palette } from './styles/palette';
+
+export default Divider;
+
+export type { DividerProps };
+
+export const MuiDividerStyleOverrides = {
+  root: {
+    height: 2,
+    backgroundColor: palette.grey.medium,
+  },
+};

--- a/libs/spark/src/Divider.ts
+++ b/libs/spark/src/Divider.ts
@@ -1,5 +1,4 @@
-import { Divider } from '@material-ui/core';
-import type { DividerProps } from '@material-ui/core';
+import { Divider, DividerProps } from '@material-ui/core';
 import { palette } from './styles/palette';
 
 export default Divider;

--- a/libs/spark/src/List.ts
+++ b/libs/spark/src/List.ts
@@ -1,5 +1,4 @@
-import { List } from '@material-ui/core';
-import type { ListProps } from '@material-ui/core';
+import { List, ListProps } from '@material-ui/core';
 
 export default List;
 

--- a/libs/spark/src/List.ts
+++ b/libs/spark/src/List.ts
@@ -1,0 +1,12 @@
+import { List } from '@material-ui/core';
+import type { ListProps } from '@material-ui/core';
+
+export default List;
+
+export type { ListProps };
+
+export const MuiListStyleOverrides = {
+  subheader: {
+    paddingTop: 8,
+  },
+};

--- a/libs/spark/src/ListSubheader.ts
+++ b/libs/spark/src/ListSubheader.ts
@@ -1,0 +1,23 @@
+import {
+  ListSubheader,
+  ListSubheaderClassKey,
+  StyleRules,
+  ListSubheaderProps,
+} from '@material-ui/core';
+import { palette } from './styles/palette';
+import { typography } from './styles/typography';
+
+export default ListSubheader;
+
+export type { ListSubheaderProps };
+
+export const MuiListSubheaderStyleOverrides: Partial<
+  StyleRules<ListSubheaderClassKey>
+> = {
+  root: {
+    ...typography['uppercase-sm'],
+    // NOTE: divisor should be font size of above, in pixels
+    lineHeight: 28 / 12,
+    color: palette.text.onLightLowContrast,
+  },
+};

--- a/libs/spark/src/MenuItem.tsx
+++ b/libs/spark/src/MenuItem.tsx
@@ -5,7 +5,9 @@ import { typography } from './styles/typography';
 
 export { MenuItem };
 
-export const MuiMenuItemStyleOverrides: Partial<StyleRules<MenuItemClassKey>> = {
+export const MuiMenuItemStyleOverrides: Partial<
+  StyleRules<MenuItemClassKey>
+> = {
   root: {
     ...typography['label-lg'],
     boxSizing: 'border-box' as const,

--- a/libs/spark/src/MenuItem.tsx
+++ b/libs/spark/src/MenuItem.tsx
@@ -20,8 +20,7 @@ export const MuiMenuItemStyleOverrides: Partial<
     paddingBottom: 4,
     paddingRight: 14,
     paddingLeft: 14,
-    // margins collapse with other menu items
-    margin: '4px 0',
+    margin: 0,
     '&:first-child': {
       marginTop: 0,
     },

--- a/libs/spark/src/MenuItem.tsx
+++ b/libs/spark/src/MenuItem.tsx
@@ -5,9 +5,7 @@ import { typography } from './styles/typography';
 
 export { MenuItem };
 
-export const MuiMenuItemStyleOverrides: Partial<
-  StyleRules<MenuItemClassKey>
-> = {
+export const MuiMenuItemStyleOverrides: Partial<StyleRules<MenuItemClassKey>> = {
   root: {
     ...typography['label-lg'],
     boxSizing: 'border-box' as const,

--- a/libs/spark/src/MenuList.tsx
+++ b/libs/spark/src/MenuList.tsx
@@ -1,0 +1,6 @@
+import { MenuList } from '@material-ui/core';
+import type { MenuListProps } from '@material-ui/core';
+
+export default MenuList;
+
+export type { MenuListProps };

--- a/libs/spark/src/MenuList.tsx
+++ b/libs/spark/src/MenuList.tsx
@@ -1,5 +1,4 @@
-import { MenuList } from '@material-ui/core';
-import type { MenuListProps } from '@material-ui/core';
+import { MenuList, MenuListProps } from '@material-ui/core';
 
 export default MenuList;
 

--- a/libs/spark/src/Paper.ts
+++ b/libs/spark/src/Paper.ts
@@ -1,5 +1,4 @@
-import { Paper } from '@material-ui/core';
-import type { PaperProps } from '@material-ui/core';
+import { Paper, PaperProps } from '@material-ui/core';
 
 export default Paper;
 

--- a/libs/spark/src/Paper.ts
+++ b/libs/spark/src/Paper.ts
@@ -1,0 +1,6 @@
+import { Paper } from '@material-ui/core';
+import type { PaperProps } from '@material-ui/core';
+
+export default Paper;
+
+export type { PaperProps };

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -8,6 +8,10 @@ export { CardActions } from './CardActions';
 export { CardContent } from './CardContent';
 export { CardMedia } from './CardMedia';
 export { Checkbox } from './Checkbox';
+
+export { default as Divider } from './Divider';
+export * from './Divider';
+
 export {
   DropdownContext,
   DropdownButton,
@@ -36,10 +40,22 @@ export { ListItem } from './ListItem';
 export { ListItemAvatar } from './ListItemAvatar';
 export { ListItemIcon } from './ListItemIcon';
 export { ListItemText } from './ListItemText';
+
+export { default as ListSubheader } from './ListSubheader';
+export * from './ListSubheader';
+
 export { Menu } from './Menu';
 export { MenuItem } from './MenuItem';
+
+export { default as MenuList } from './MenuList';
+export * from './MenuList';
+
 export { Pagination } from './Pagination';
 export { PaginationItem } from './PaginationItem';
+
+export { default as Paper } from './Paper';
+export * from './Paper';
+
 export { Radio } from './Radio';
 export { RadioGroup } from './RadioGroup';
 export { Select } from './Select';

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -1,5 +1,6 @@
 import { MuiAvatarStyleOverrides } from '../Avatar';
 import { MuiButtonStyleOverrides } from '../Button';
+import { MuiDividerStyleOverrides } from '../Divider';
 import { MuiCardStyleOverrides } from '../Card';
 import { MuiCardContentStyleOverrides } from '../CardContent';
 import { MuiCardActionsStyleOverrides } from '../CardActions';
@@ -12,10 +13,12 @@ import { MuiInputStyleOverrides } from '../Input';
 import { MuiInputAdornmentStylesOverrides } from '../InputAdornment';
 import { MuiInputBaseStyleOverrides } from '../InputBase';
 import { MuiInputLabelStyleOverrides } from '../InputLabel';
+import { MuiListStyleOverrides } from '../List';
 import { MuiListItemStyleOverrides } from '../ListItem';
 import { MuiListItemAvatarStyleOverrides } from '../ListItemAvatar';
 import { MuiListItemIconStyleOverrides } from '../ListItemIcon';
 import { MuiListItemTextStyleOverrides } from '../ListItemText';
+import { MuiListSubheaderStyleOverrides } from '../ListSubheader';
 import { MuiMenuStyleOverrides } from '../Menu';
 import { MuiMenuItemStyleOverrides } from '../MenuItem';
 import { MuiPaginationStyleOverrides } from '../Pagination';
@@ -42,6 +45,7 @@ export const overrides = {
   MuiCardContent: MuiCardContentStyleOverrides,
   MuiCardActions: MuiCardActionsStyleOverrides,
   MuiCheckbox: MuiCheckboxStyleOverrides,
+  MuiDivider: MuiDividerStyleOverrides,
   MuiFormControlLabel: MuiFormControlLabelStyleOverrides,
   MuiFormHelperText: MuiFormHelperTextStyleOverrides,
   MuiFormLabel: MuiFormLabelStyleOverrides,
@@ -50,10 +54,12 @@ export const overrides = {
   MuiInputAdornment: MuiInputAdornmentStylesOverrides,
   MuiInputBase: MuiInputBaseStyleOverrides,
   MuiInputLabel: MuiInputLabelStyleOverrides,
+  MuiList: MuiListStyleOverrides,
   MuiListItem: MuiListItemStyleOverrides,
   MuiListItemAvatar: MuiListItemAvatarStyleOverrides,
   MuiListItemIcon: MuiListItemIconStyleOverrides,
   MuiListItemText: MuiListItemTextStyleOverrides,
+  MuiListSubheader: MuiListSubheaderStyleOverrides,
   MuiMenu: MuiMenuStyleOverrides,
   MuiMenuItem: MuiMenuItemStyleOverrides,
   MuiPagination: MuiPaginationStyleOverrides,

--- a/libs/spark/stories/menulist.stories.tsx
+++ b/libs/spark/stories/menulist.stories.tsx
@@ -9,7 +9,6 @@ import {
   ListSubheader,
   MenuItem,
   MenuList,
-  styled,
   Divider,
   Paper,
   withStyles,

--- a/libs/spark/stories/menulist.stories.tsx
+++ b/libs/spark/stories/menulist.stories.tsx
@@ -1,0 +1,193 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  Avatar,
+  Checkbox,
+  ListItemAvatar,
+  ListItemText,
+  ListItemIcon,
+  ListSubheader,
+  MenuItem,
+  MenuList,
+  styled,
+  Divider,
+  Paper,
+  withStyles,
+} from '../src';
+import { DocTemplate } from './documentation-template';
+import { ChangelogTemplate } from './changelog-template';
+
+export default {
+  title: 'prenda-spark/MenuList',
+  component: MenuList,
+  argTypes: {},
+  args: {},
+} as Meta;
+
+const CustomPaper = withStyles((theme) => ({
+  root: {
+    borderRadius: 16,
+    width: 256,
+    maxHeight: 40 * 8 + 16,
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    scrollbarColor: `${theme.palette.text.onLightLowContrast} transparent`,
+  },
+}))(Paper);
+
+export const Basic = (args) => (
+  <CustomPaper elevation={4}>
+    <MenuList {...args}>
+      {['Profile', 'Resources', 'Menu item', 'Sign out'].map((primary) => (
+        <MenuItem key={primary}>
+          <ListItemText primary={primary} />
+        </MenuItem>
+      ))}
+    </MenuList>
+  </CustomPaper>
+);
+
+export const Sectioned = (args) => (
+  <CustomPaper elevation={4}>
+    <MenuList {...args}>
+      {['Profile', 'Resources'].map((primary) => (
+        <MenuItem key={primary}>
+          <ListItemText primary={primary} />
+        </MenuItem>
+      ))}
+      <Divider component="li" />
+      {['Menu item', 'Sign out'].map((primary) => (
+        <MenuItem key={primary}>
+          <ListItemText primary={primary} />
+        </MenuItem>
+      ))}
+    </MenuList>
+  </CustomPaper>
+);
+
+export const Checkboxes = (args) => (
+  <CustomPaper elevation={4}>
+    <MenuList {...args}>
+      {[1, 2, 3, 4, 5, 6, 7].map((i) => (
+        <MenuItem key={i}>
+          <ListItemIcon>
+            <Checkbox
+              tabIndex={-1}
+              inputProps={{ 'aria-labelledby': `menu-item-label-${i}` }}
+              checked={[4, 6].includes(i)}
+            />
+          </ListItemIcon>
+          <ListItemText id={`menu-item-label-${i}`} primary="Label" />
+        </MenuItem>
+      ))}
+    </MenuList>
+  </CustomPaper>
+);
+
+export const Avatars = (args) => (
+  <CustomPaper elevation={4}>
+    <MenuList {...args}>
+      {[
+        {
+          src: '/img/student-girl-1.png',
+          primary: 'Sarah',
+        },
+        {
+          src: '/img/student-boy-1.png',
+          primary: 'Jones',
+        },
+        {
+          src: '/img/student-girl-3.png',
+          primary: 'Sam',
+        },
+        {
+          src: '/img/guide-3.png',
+          primary: 'Samson',
+        },
+        {
+          src: '/img/student-boy-3.png',
+          primary: 'Jake',
+        },
+        {
+          src: '/img/student-boy-2.png',
+          primary: 'Michael',
+        },
+        {
+          src: '/img/student-girl-2.png',
+          primary: 'Ali',
+        },
+      ].map(({ src, primary }) => (
+        <MenuItem key={src}>
+          <ListItemAvatar>
+            <Avatar size="xsmall" src={src} />
+          </ListItemAvatar>
+          <ListItemText primary={primary} />
+        </MenuItem>
+      ))}
+    </MenuList>
+  </CustomPaper>
+);
+
+export const Scrolling = (args) => (
+  <CustomPaper elevation={4}>
+    <MenuList {...args}>
+      {Array.from(Array(16).keys()).map((i) => (
+        <MenuItem key={i}>
+          <ListItemText primary="Menu item" />
+        </MenuItem>
+      ))}
+    </MenuList>
+  </CustomPaper>
+);
+
+export const SectionTitle = (args) => (
+  <CustomPaper elevation={4}>
+    <MenuList
+      subheader={
+        <ListSubheader component="div" id="menu-list-subheader">
+          Title
+        </ListSubheader>
+      }
+      {...args}
+    >
+      {['Profile', 'Resources', 'Menu item', 'Sign out'].map((primary) => (
+        <MenuItem key={primary}>
+          <ListItemText primary={primary} />
+        </MenuItem>
+      ))}
+    </MenuList>
+  </CustomPaper>
+);
+
+const MenuListDocTemplate = (args) => <DocTemplate {...args} />;
+
+export const Documentation: Story = MenuListDocTemplate.bind({});
+Documentation.args = {
+  underlyingComponent: {
+    name: 'MenuList',
+    href: 'https://material-ui.com/components/menus/',
+  },
+  props: {
+    extends: {
+      href: 'https://material-ui.com/api/menu-list/#props',
+    },
+  },
+  css: {
+    extends: {
+      href: 'https://material-ui.com/api/menu-item/#css',
+    },
+  },
+};
+
+const MenuListChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
+
+export const Changelog: Story = MenuListChangelogTemplate.bind({});
+Changelog.args = {
+  history: [
+    {
+      version: 'vNext',
+      versionDate: 'yyyy-mm-dd',
+      changes: ['Initial styling implementation.'],
+    },
+  ],
+};

--- a/libs/spark/stories/tag.stories.tsx
+++ b/libs/spark/stories/tag.stories.tsx
@@ -142,11 +142,11 @@ export const Documentation: Story = AvatarDocTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Chip',
-    href: 'https://material-ui.com/components/avatars/#avatar',
+    href: 'https://material-ui.com/components/chips/#chip',
   },
   props: {
     extends: {
-      href: 'https://material-ui.com/api/avatar/#props',
+      href: 'https://material-ui.com/api/chip/#props',
     },
     omits: [
       {


### PR DESCRIPTION
Closes #211 .

Adds re-export and stories for `MenuList`. This is the true-est parent component of `MenuItem`'s. The `Menu` component is for controlling `Popper` logic which isn't the point of our styling validations. For more, see https://material-ui.com/components/menus/#menulist-composition.

Six stories from Figma examples
  - Basic (plain menu items)
  - Sectioned, where a `Divider` appears halfway
    - Divider is it's own component, now with style support and a re-export
  - Checkboxes
  - Avatars
  - Scrolling
    - note: scrollbar's can't be reliably customized on the Web like the Figma page shows, the most i could do was change the track and thumb colors. Making the width "thin" would have introduced a11y concerns.
  - Section Title, where the `ListSubheader` is used
    - it's own component, now with style support, re-exported

Also re-exports were added for `Paper` and `List` as I needed to use and style override them, respectively.

You'll notice that I used a bit of a different pattern for re-exports, where the component gets a default export and everything else would be named. That requires a bit of a different style in `index.js` then as well. The intention behind this is to keep in mind our eventual need to support deep-imports, import transformation, etc. as our bundle size grows, with a custom build action just like the icons package. See #213 for tracking.