### PR TITLE
feat(Autocomplete): initial support for use-case

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### Features
 
+- **Autocomplete**
+  - Added re-export.
+  - Added initial styling support: multiple Checkboxes.
 - **Avatar**
   - Initial implementation.
 - **Divider**

--- a/libs/spark/src/Autocomplete.tsx
+++ b/libs/spark/src/Autocomplete.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import {
+  Autocomplete,
+  AutocompleteClassKey,
+  AutocompleteProps,
+} from '@material-ui/lab';
+import { palette } from './styles/palette';
+import ChevronDownIcon from './internal/ChevronDown';
+import { typography } from './styles/typography';
+import { StyleRules } from '@material-ui/core';
+
+export default Autocomplete;
+
+export type { AutocompleteProps };
+
+export const MuiAutocompleteStyleOverrides: Partial<
+  StyleRules<AutocompleteClassKey>
+> = {
+  input: {
+    padding: '10px 16px',
+  },
+  inputRoot: {
+    backgroundColor: palette.common.white,
+    '&[class*="MuiInput-root"]': {
+      paddingBottom: 0,
+      '& $input': {
+        padding: '10px 8px',
+      },
+      '& $input:first-child': {
+        padding: '10px 16px',
+      },
+    },
+    '&[class*="MuiInputBase-adornedStart"]': {
+      paddingLeft: 8,
+    },
+    '&[class*="MuiInputBase-adornedEnd"]': {
+      paddingRight: 42,
+    },
+  },
+  endAdornment: {
+    right: 16,
+  },
+  popupIndicator: {
+    transition: 'transform 250ms ease',
+  },
+  // largely a copy of MenuItem's style overrides
+  option: {
+    ...typography['label-lg'],
+    boxSizing: 'border-box' as const,
+    color: palette.text.onLight,
+    minWidth: 228,
+    minHeight: '2.125rem', // 34px
+    border: '2px solid transparent',
+    // have to separate to override
+    paddingTop: 4,
+    paddingBottom: 4,
+    paddingRight: 14,
+    paddingLeft: 14,
+    margin: 0,
+    '&:first-child': {
+      marginTop: 0,
+    },
+    '&:last-child': {
+      marginBottom: 0,
+    },
+    // won't receive true hover or focus, just data-focus
+    '&[data-focus="true"]': {
+      backgroundColor: palette.grey.light,
+      borderColor: palette.grey.light,
+    },
+    '&:active': {
+      backgroundColor: palette.grey.medium,
+      borderColor: palette.blue[4],
+    },
+
+    '&[aria-selected="true"][data-focus="true"]': {
+      backgroundColor: palette.blue[3],
+      borderColor: palette.blue[3],
+      color: palette.common.white,
+    },
+    // won't receive true focus
+    '&[aria-selected="true"]:active': {
+      backgroundColor: palette.blue[4],
+      borderColor: palette.blue[5],
+      color: palette.common.white,
+    },
+  },
+};
+
+export const MuiAutocompleteDefaultProps = {
+  popupIcon: <ChevronDownIcon />,
+};

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -1,4 +1,8 @@
 export { styled, useTheme, withStyles, makeStyles } from '@material-ui/core';
+
+export { default as Autocomplete } from './Autocomplete';
+export * from './Autocomplete';
+
 export { Avatar } from './Avatar';
 export { Box } from './Box';
 export { Button } from './Button';

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -1,3 +1,4 @@
+import { MuiAutocompleteStyleOverrides } from '../Autocomplete';
 import { MuiAvatarStyleOverrides } from '../Avatar';
 import { MuiButtonStyleOverrides } from '../Button';
 import { MuiDividerStyleOverrides } from '../Divider';
@@ -30,6 +31,7 @@ import { MuiTypographyStyleOverrides } from '../Typography';
 import { fontFaces, typography } from './typography';
 
 export const overrides = {
+  MuiAutocomplete: MuiAutocompleteStyleOverrides,
   MuiAvatar: MuiAvatarStyleOverrides,
   MuiButton: MuiButtonStyleOverrides,
   MuiCssBaseline: {

--- a/libs/spark/src/styles/props.ts
+++ b/libs/spark/src/styles/props.ts
@@ -1,3 +1,4 @@
+import { MuiAutocompleteDefaultProps } from '..';
 import { MuiButtonDefaultProps } from '../Button';
 import { MuiButtonBaseDefaultProps } from '../ButtonBase';
 import { MuiCardDefaultProps } from '../Card';
@@ -13,6 +14,7 @@ import { MuiSelectDefaultProps } from '../Select';
 import { MuiSvgIconDefaultProps } from '../SvgIcon';
 
 export const props = {
+  MuiAutocomplete: MuiAutocompleteDefaultProps,
   MuiButton: MuiButtonDefaultProps,
   MuiButtonBase: MuiButtonBaseDefaultProps,
   MuiCard: MuiCardDefaultProps,

--- a/libs/spark/stories/autocomplete.stories.tsx
+++ b/libs/spark/stories/autocomplete.stories.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  Autocomplete,
+  Checkbox,
+  ListItemText,
+  ListItemIcon,
+  TextField,
+  Tag,
+} from '../src';
+import { DocTemplate } from './documentation-template';
+import { ChangelogTemplate } from './changelog-template';
+
+export default {
+  title: 'prenda-spark/Autocomplete',
+  component: Autocomplete,
+  argTypes: {},
+  args: {},
+} as Meta;
+
+const reasons = [
+  { value: '1', label: 'Label' },
+  { value: '2', label: 'Label' },
+  { value: '3', label: 'Label' },
+  { value: '4', label: 'Customer service' },
+  { value: '5', label: 'Label' },
+  { value: '6', label: 'Too expensive' },
+  { value: '7', label: 'Label' },
+];
+
+export const MultipleValuesCheckboxes = (args) => (
+  <Autocomplete
+    multiple
+    options={reasons}
+    disableCloseOnSelect
+    disableClearable
+    getOptionLabel={({ label }) => label}
+    style={{ width: 320 }}
+    renderOption={(
+      { value, label }: { value: string; label: string },
+      { selected }
+    ) => (
+      <>
+        <ListItemIcon>
+          <Checkbox
+            tabIndex={-1}
+            inputProps={{ 'aria-labelledby': `label-for-${value}` }}
+            checked={selected}
+          />
+        </ListItemIcon>
+        <ListItemText id={`label-for-${value}`} primary={label} />
+      </>
+    )}
+    renderInput={(params) => (
+      <TextField
+        {...params}
+        label="Reasons for leaving this microschool?"
+        placeholder="Reason"
+      />
+    )}
+    renderTags={(value, getTagProps) =>
+      value.map(({ label }, index) => (
+        <Tag label={label} {...getTagProps({ index })} />
+      ))
+    }
+    {...args}
+  />
+);
+
+const AutocompleteDocTemplate = (args) => <DocTemplate {...args} />;
+
+export const Documentation: Story = AutocompleteDocTemplate.bind({});
+Documentation.args = {
+  underlyingComponent: {
+    name: 'Autocomplete',
+    href: 'https://material-ui.com/components/autocomplete',
+  },
+  props: {
+    extends: {
+      href: 'https://material-ui.com/api/autocomplete/#props',
+    },
+  },
+  css: {
+    extends: {
+      href: 'https://material-ui.com/api/autocomplete/#css',
+    },
+  },
+};
+
+const AutocompleteChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
+
+export const Changelog: Story = AutocompleteChangelogTemplate.bind({});
+Changelog.args = {
+  history: [
+    {
+      version: 'vNext',
+      versionDate: 'yyyy-mm-dd',
+      changes: ['Initial styling implementation.'],
+    },
+  ],
+};


### PR DESCRIPTION
Closes #212.

Implements the "multiple checkbox select with tag rendering" use-case shown in the 'Select Field" Figma page.

This incorporates a lot of recent work:
 - `Tag`'s for selected option rendering
 - Checkbox items for option rendering
 - `MenuItem` styling ported to `Autocomplete`'s `option` classes slot
   - it was unfortunate to learn it doesn't actually use `MenuItem`'s for its options!

Adds the story for this single use-case.

This really is just the initial support for this component. This component can do _so_ much, but this use-case is the only one outlined so far in Figma.