### PR TITLE
fix(Button): padding for all sizes

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Button**
   - Corrected start/end icon margins.
   - Corrected height when `size="small"`.
+  - Corrected padding for all sizes.
 - **Input**
   - See **InputBase**.
 - **InputBase**

--- a/libs/spark/src/Button.ts
+++ b/libs/spark/src/Button.ts
@@ -16,6 +16,8 @@ export const MuiButtonDefaultProps = {
 export const MuiButtonStyleOverrides: Partial<StyleRules<ButtonClassKey>> = {
   root: {
     ...typography['label-lg-strong'],
+    // account for 2px border width
+    padding: `${typography.pxToRem(6 - 2)} ${typography.pxToRem(16 - 2)}`,
     borderRadius: 24,
     borderWidth: '2px',
     borderStyle: 'solid' as const,
@@ -25,7 +27,6 @@ export const MuiButtonStyleOverrides: Partial<StyleRules<ButtonClassKey>> = {
   },
   contained: {
     boxShadow: 'none',
-    padding: '4px 16px', // y-dim accounts for 2px border width
     border: `2px solid ${palette.blue[3]}`,
     backgroundColor: palette.blue[3],
     color: palette.common.white,
@@ -49,7 +50,6 @@ export const MuiButtonStyleOverrides: Partial<StyleRules<ButtonClassKey>> = {
   },
   outlined: {
     boxShadow: 'none',
-    padding: '4px 16px', // y-dim accounts for 2px border width
     // re-declare to override default outlined style
     border: `2px solid ${palette.grey.medium}`,
     backgroundColor: palette.common.white,
@@ -73,8 +73,6 @@ export const MuiButtonStyleOverrides: Partial<StyleRules<ButtonClassKey>> = {
   },
   text: {
     boxShadow: 'none',
-    // x-dim accounts for 2px border width
-    padding: `${typography.pxToRem(4)} ${typography.pxToRem(16)}`,
     border: '2px solid transparent',
     backgroundColor: 'transparent',
     color: palette.blue[3],
@@ -100,14 +98,13 @@ export const MuiButtonStyleOverrides: Partial<StyleRules<ButtonClassKey>> = {
   },
   sizeLarge: {
     ...typography['label-xl-strong'],
-    // x-dim accounts for 2px border width
-    padding: `${typography.pxToRem(12)} ${typography.pxToRem(16)}`,
+    // account for 2px border width
+    padding: `${typography.pxToRem(14 - 2)} ${typography.pxToRem(16 - 2)}`,
   },
   sizeSmall: {
     ...typography['label-sm-strong'],
-    lineHeight: typography.pxToRem(12),
-    // x-dim accounts for 2px border width
-    padding: `${typography.pxToRem(4)} ${typography.pxToRem(16)}`,
+    // account for 2px border width
+    padding: `${typography.pxToRem(2 - 2)} ${typography.pxToRem(16 - 2)}`,
   },
   label: {
     color: 'inherit',


### PR DESCRIPTION
Closes #202 .

- Removed custom line height for small button and adjusted padding accordingly
- Removed padding set per variant and sets it on `root` instead.
- Corrected x-dimension padding to be 14px accounting for 2px border width.

In the effort to reduce comments and reducing where code take mental effort to compare to Figma values, I left basic arithmetic expression in the `pxToRem` function calls. The reasoning is that designers use inside borders on the main element, so the measurement displayed from the label edges to the buttons edges aren't a reflection of the `padding` value, its the padding - border width.