### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See project specific changelogs for details
 - [`@prenda/spark` here](https://github.com/prenda-school/prenda-spark/blob/main/libs/spark/CHANGELOG.md)
 - [`@prenda/spark-icons` here](https://github.com/prenda-school/prenda-spark/blob/main/libs/spark-icons/CHANGELOG.md)
 
-# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...vNext) (yyyy-mm-dd)
+# [v0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 
 # [0.10.0](https://github.com/prenda-school/prenda-spark/compare/v0.9.0...v0.10.0) (2021-08-06)
 

--- a/libs/spark-icons/CHANGELOG.md
+++ b/libs/spark-icons/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
+# [0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
+
+### Fixes
+
+- camelCase missed `stroke-*` attributes
+  - affected icons: `BeakerDuotone`, `HighFiveDuotone`, `MountainDuotone`, `Users3Duotone`
 
 # [0.10.0](https://github.com/prenda-school/prenda-spark/compare/v0.9.0...v0.10.0) (2021-08-06)
 

--- a/libs/spark-icons/package.json
+++ b/libs/spark-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prenda/spark-icons",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "author": "Prenda",
   "license": "MIT",
   "publishConfig": {
@@ -12,7 +12,7 @@
     "@babel/runtime": "^7.10.2"
   },
   "peerDependencies": {
-    "@prenda/spark": "^0.10.0",
+    "@prenda/spark": "^0.11.0",
     "react": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...vNext) (yyyy-mm-dd)
+# [v0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 
 ### Fixes
 
@@ -28,6 +28,8 @@
   - Added initial styling support: multiple Checkboxes.
 - **Avatar**
   - Initial implementation.
+- **Card**
+  - Updated elevation (design change).
 - **Divider**
   - Added re-export.
   - Added minimal styling related to **MenuList** styling support.
@@ -52,6 +54,8 @@
 - **ListSubheader**
   - Added re-export.
   - Added minimal styling related to **MenuList** styling support.
+- **Menu**
+  - Updated elevation (design change).
 - **MenuItem**
   - Added styling for pseudo-states: `:hover`, `:focus`, `:active`
   - Added styling for content: `ListItemText`, `ListItemIcon`, `ListItemAvatar`, `ListItem`
@@ -69,6 +73,7 @@
 - **TextField**
   - See **InputBase**.
 - **Typography**
+  - Updated variant font-weights (design change).
   - New `color` prop values:
     - `'onLight'`
     - `'onLightLowContrast'`
@@ -111,7 +116,7 @@
     - `theme.typography['code-lg']`
     - `theme.typography['code-md']`
     - `theme.typography['code-sm']`
-  - Customized default `theme.typography` keys
+  - Customized default `theme.typography` keys:
     - `theme.typography.h1` as `theme.typography['display-md']`
     - `theme.typography.h2` as `theme.typography['display-sm']`
     - `theme.typography.h3` as `theme.typography['heading-xl']`
@@ -125,6 +130,8 @@
     - `theme.typography.button` as `theme.typography['label-lg']`
     - `theme.typography.caption` as `theme.typography['label-sm']`
     - `theme.typography.overline` as `theme.typography['uppercase-sm']`
+  - Updated `theme.shadows` (design change).
+    - Design specifies five elevations (shadows): E100, E200, ..., E500. These correspond to `theme.shadows[1...5]`, respectively. The remaining keys (6...24) are equal to the highest elevation, E500 (`theme.shadows[5]`).
 
 #### Breaking Changes
 

--- a/libs/spark/package.json
+++ b/libs/spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prenda/spark",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "author": "Prenda",
   "license": "MIT",
   "publishConfig": {

--- a/libs/spark/stories/autocomplete.stories.tsx
+++ b/libs/spark/stories/autocomplete.stories.tsx
@@ -93,8 +93,8 @@ export const Changelog: Story = AutocompleteChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {
-      version: 'vNext',
-      versionDate: 'yyyy-mm-dd',
+      version: 'v0.11.0',
+      versionDate: '2021-08-21',
       changes: ['Initial styling implementation.'],
     },
   ],

--- a/libs/spark/stories/avatar.stories.tsx
+++ b/libs/spark/stories/avatar.stories.tsx
@@ -159,8 +159,8 @@ export const Changelog: Story = AvatarChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {
-      version: 'vNext',
-      versionDate: 'yyyy-mm-dd',
+      version: 'v0.11.0',
+      versionDate: '2021-08-21',
       changes: ['Initial implementation'],
     },
   ],

--- a/libs/spark/stories/input.stories.tsx
+++ b/libs/spark/stories/input.stories.tsx
@@ -154,8 +154,8 @@ export const Changelog: Story = InputChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {
-      version: 'vNext',
-      versionDate: 'yyyy-mm-dd',
+      version: 'v0.11.0',
+      versionDate: '2021-08-21',
       changes: ['Added styling for `startAdornment` and `endAdornment` props.'],
     },
     {

--- a/libs/spark/stories/menuitem.stories.tsx
+++ b/libs/spark/stories/menuitem.stories.tsx
@@ -142,8 +142,8 @@ export const Changelog: Story = MenuItemChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {
-      version: 'vNext',
-      versionDate: 'yyyy-mm-dd',
+      version: 'v0.11.0',
+      versionDate: '2021-08-21',
       changes: [
         'Added styling for pseudo-states: `:hover`, `:focus`, `:active`',
         'Added styling for content: `ListItemText`, `ListItemIcon`, `ListItemAvatar`, `ListItem`',

--- a/libs/spark/stories/menulist.stories.tsx
+++ b/libs/spark/stories/menulist.stories.tsx
@@ -184,8 +184,8 @@ export const Changelog: Story = MenuListChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {
-      version: 'vNext',
-      versionDate: 'yyyy-mm-dd',
+      version: 'v0.11.0',
+      versionDate: '2021-08-21',
       changes: ['Initial styling implementation.'],
     },
   ],

--- a/libs/spark/stories/select.stories.tsx
+++ b/libs/spark/stories/select.stories.tsx
@@ -126,8 +126,8 @@ export const Changelog: Story = SelectChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {
-      version: 'vNext',
-      versionDate: 'yyyy-mm-dd',
+      version: 'v0.11.0',
+      versionDate: '2021-08-21',
       changes: ['See Input'],
     },
     {

--- a/libs/spark/stories/tag.stories.tsx
+++ b/libs/spark/stories/tag.stories.tsx
@@ -230,8 +230,8 @@ export const Changelog: Story = AvatarChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {
-      version: 'vNext',
-      versionDate: 'yyyy-mm-dd',
+      version: 'v0.11.0',
+      versionDate: '2021-08-21',
       changes: ['Initial implementation'],
     },
   ],

--- a/libs/spark/stories/text-field.stories.tsx
+++ b/libs/spark/stories/text-field.stories.tsx
@@ -257,8 +257,8 @@ export const Changelog: Story = TextFieldChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {
-      version: 'vNext',
-      versionDate: 'yyyy-mm-dd',
+      version: 'v0.11.0',
+      versionDate: '2021-08-21',
       changes: ['See Input'],
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prenda-spark",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "scripts": {
     "nx": "nx",


### PR DESCRIPTION
- [x] Adds missing manual history from 3 post v0.10 PR's
- [x] Increments package & workspace versions
- [x] Replaces "vNext" and "(yyyy-mm-dd)" in changelogs (down to component stories) with new version num and release date.
- [x] Tag last commit with annotation of version num and message of commit message (PR title). Pushes tag to remote.