### PR TITLE
chore(release): 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See project specific changelogs for details
 - [`@prenda/spark` here](https://github.com/prenda-school/prenda-spark/blob/main/libs/spark/CHANGELOG.md)
 - [`@prenda/spark-icons` here](https://github.com/prenda-school/prenda-spark/blob/main/libs/spark-icons/CHANGELOG.md)
 
-# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...vNext) (yyyy-mm-dd)
+# [v0.11.1](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...v0.11.1) (2021-09-07)
 
 # [v0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ See project specific changelogs for details
 - [`@prenda/spark` here](https://github.com/prenda-school/prenda-spark/blob/main/libs/spark/CHANGELOG.md)
 - [`@prenda/spark-icons` here](https://github.com/prenda-school/prenda-spark/blob/main/libs/spark-icons/CHANGELOG.md)
 
+# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...vNext) (yyyy-mm-dd)
+
 # [v0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 
 # [0.10.0](https://github.com/prenda-school/prenda-spark/compare/v0.9.0...v0.10.0) (2021-08-06)

--- a/apps/spark-e2e/CHANGELOG.md
+++ b/apps/spark-e2e/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Changelog
-
-This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
-
-# [0.9.0](https://github.com/prenda-school/prenda-spark/compare/v0.8.0...v0.9.0) (2021-07-29)
-
-# [0.8.0](https://github.com/prenda-school/prenda-spark/compare/v0.7.3...v0.8.0) (2021-06-22)

--- a/libs/spark-icons/CHANGELOG.md
+++ b/libs/spark-icons/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...vNext) (yyyy-mm-dd)
+# [v0.11.1](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...v0.11.1) (2021-09-07)
 
 # [0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 

--- a/libs/spark-icons/CHANGELOG.md
+++ b/libs/spark-icons/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...vNext) (yyyy-mm-dd)
+
 # [0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 
 ### Fixes

--- a/libs/spark-icons/package.json
+++ b/libs/spark-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prenda/spark-icons",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": "Prenda",
   "license": "MIT",
   "publishConfig": {

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...vNext) (yyyy-mm-dd)
+
+### Fixes
+
+- Replace internal call of `createMuiTheme` with `createTheme`
+
 # [v0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 
 ### Fixes

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...vNext) (yyyy-mm-dd)
+# [v0.11.1](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...v0.11.1) (2021-09-07)
 
 ### Fixes
 

--- a/libs/spark/package.json
+++ b/libs/spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prenda/spark",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": "Prenda",
   "license": "MIT",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prenda-spark",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "scripts": {
     "nx": "nx",


### PR DESCRIPTION
Adds missing history entry for last PR, whoops.

Removes changelog for the e2e testing app, it's not relevant in any way!

New version bump -- our first fix version that hasn't been overtaken by a feature!