### PR TITLE
chore(workflow): fix publish action failing on file-watcher limit

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,10 +7,17 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Increase system files monitor limit
+        run: sudo sysctl fs.inotify.max_user_watches=524288
+
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: '14'
+
       - run: npm ci
       - run: npx nx run spark:test
       - run: npx nx run spark-e2e:e2e


### PR DESCRIPTION
Resolves #237 