### PR TITLE
feat(Switch): initial implementation

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -12,6 +12,12 @@
     - `'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'`
 - **IconButton**
   - Forwards ref.
+- **List**
+  - Added re-export.
+  - Added minimal styling.
+- **ListItemSecondaryAction**
+  - Added re-export.
+  - Added minimal styling.
 - **Switch**
   - Initial implementation.
 

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -12,6 +12,8 @@
     - `'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'`
 - **IconButton**
   - Forwards ref.
+- **Switch**
+  - Initial implementation.
 
 ### Fixes
 

--- a/libs/spark/src/ListItemSecondaryAction.ts
+++ b/libs/spark/src/ListItemSecondaryAction.ts
@@ -1,0 +1,12 @@
+import type { ListItemSecondaryActionProps } from '@material-ui/core';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+
+export default ListItemSecondaryAction;
+
+export type { ListItemSecondaryActionProps };
+
+export const MuiListItemSecondaryActionStyleOverrides = {
+  root: {
+    right: 8,
+  },
+};

--- a/libs/spark/src/Switch.tsx
+++ b/libs/spark/src/Switch.tsx
@@ -28,6 +28,12 @@ export type SwitchProps<
 > = OverrideProps<SwitchTypeMap<P, D>, D>;
 
 export const MuiSwitchStyleOverrides = ({ palette }: Theme) => ({
+  edgeEnd: {
+    marginRight: -4,
+  },
+  edgeStart: {
+    marginLeft: -4,
+  },
   root: {
     height: 32 + 8,
     width: 56 + 8,

--- a/libs/spark/src/Switch.tsx
+++ b/libs/spark/src/Switch.tsx
@@ -27,6 +27,11 @@ export type SwitchProps<
   P = Record<string, unknown>
 > = OverrideProps<SwitchTypeMap<P, D>, D>;
 
+// :NOTE: the focus styling is implemented with a box-shadow. To prevent layout
+// shifts when that is applied, a padding of equal width is applied to the root
+// element. Property value calculations with "... + 8" or "... + 4" are explicitly
+// taking that into account where the "..." value is more reflective of the design
+// measurement than the raw sum would be.
 export const MuiSwitchStyleOverrides = ({ palette }: Theme) => ({
   edgeEnd: {
     marginRight: -4,

--- a/libs/spark/src/Switch.tsx
+++ b/libs/spark/src/Switch.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import type {
+  SwitchClassKey,
+  SwitchProps as MuiSwitchProps,
+  Theme,
+} from '@material-ui/core';
+import MuiSwitch from '@material-ui/core/Switch';
+import { OverridableComponent, OverrideProps } from './utils';
+
+export interface SwitchTypeMap<
+  P = Record<string, unknown>,
+  D extends React.ElementType = 'div'
+> {
+  props: P &
+    Omit<MuiSwitchProps, 'size' | 'color'> & {
+      /**
+       * The size of the switch.
+       */
+      size?: 'large' | 'small';
+    };
+  defaultComponent: D;
+  classKey: SwitchClassKey;
+}
+
+export type SwitchProps<
+  D extends React.ElementType = SwitchTypeMap['defaultComponent'],
+  P = Record<string, unknown>
+> = OverrideProps<SwitchTypeMap<P, D>, D>;
+
+export const MuiSwitchStyleOverrides = ({ palette }: Theme) => ({
+  root: {
+    height: 32 + 8,
+    width: 56 + 8,
+    padding: 4,
+    '& + .MuiFormControlLabel-label': {
+      marginLeft: 4,
+      '.MuiFormControlLabel-labelPlacementStart &': {
+        marginLeft: 0,
+        marginRight: 4,
+      },
+    },
+  },
+  sizeSmall: {
+    height: 24 + 8,
+    width: 48 + 8,
+    padding: 4,
+    '& $switchBase': {
+      padding: 3 + 4,
+      '&$checked': {
+        transform: 'translateX(24px)',
+      },
+    },
+    '& $thumb': {
+      width: 18,
+      height: 18,
+    },
+    '& $track': {
+      borderRadius: 14,
+    },
+  },
+  switchBase: {
+    padding: 4 + 4,
+    '&$checked': {
+      transform: 'translateX(24px)',
+      '& + $track': {
+        backgroundColor: palette.blue[3],
+        opacity: 1,
+      },
+    },
+    '&$disabled': {
+      '& + $track, &$checked + $track': {
+        opacity: 1,
+        backgroundColor: palette.grey.medium,
+      },
+      '& $thumb': {
+        backgroundColor: palette.grey.dark,
+        boxShadow: 'none',
+      },
+    },
+    '&:hover': {
+      backgroundColor: 'unset',
+      '& + $track': {
+        backgroundColor: palette.grey.dark,
+      },
+      '&$checked + $track': {
+        backgroundColor: palette.blue[2],
+      },
+    },
+    '&:focus, &.Mui-focusVisible': {
+      '& + $track': {
+        boxShadow: `0px 0px 0px 4px ${palette.blue[1]}`,
+      },
+    },
+  },
+  thumb: {
+    width: 24,
+    height: 24,
+    boxShadow:
+      '0px 0px 2px rgba(7, 46, 68, 0.16), 0px 2px 2px rgba(7, 46, 68, 0.16)',
+  },
+  track: {
+    backgroundColor: palette.grey.medium,
+    borderRadius: 16,
+    opacity: 1,
+  },
+});
+
+const Switch: OverridableComponent<SwitchTypeMap> = React.forwardRef(
+  function Switch({ size: passedSize = 'small', ...other }, ref) {
+    // Spark spec's large & small, Mui spec's medium and small => map large to medium.
+    const size = passedSize === 'large' ? 'medium' : passedSize;
+
+    return <MuiSwitch size={size} color="default" ref={ref} {...other} />;
+  }
+);
+
+export default Switch;

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -117,6 +117,9 @@ export { default as SparkThemeProvider } from './SparkThemeProvider';
 export { default as SvgIcon } from './SvgIcon';
 export * from './SvgIcon';
 
+export { default as Switch } from './Switch';
+export * from './Switch';
+
 export { default as Tag } from './Tag';
 export * from './Tag';
 

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -139,7 +139,7 @@ export { default as makeStyles } from './makeStyles';
 
 export { default as styled } from './styled';
 
-export { theme } from './styles';
+export * from './styles';
 
 export { default as useTheme } from './useTheme';
 

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -139,7 +139,7 @@ export { default as makeStyles } from './makeStyles';
 
 export { default as styled } from './styled';
 
-export * from './styles';
+export { theme } from './styles';
 
 export { default as useTheme } from './useTheme';
 

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -70,6 +70,9 @@ export * from './InputBase';
 export { default as InputLabel } from './InputLabel';
 export * from './InputLabel';
 
+export { default as List } from './List';
+export * from './List';
+
 export { default as ListItem } from './ListItem';
 export * from './ListItem';
 
@@ -81,6 +84,9 @@ export * from './ListItemIcon';
 
 export { default as ListItemText } from './ListItemText';
 export * from './ListItemText';
+
+export { default as ListItemSecondaryAction } from './ListItemSecondaryAction';
+export * from './ListItemSecondaryAction';
 
 export { default as ListSubheader } from './ListSubheader';
 export * from './ListSubheader';

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -34,6 +34,7 @@ import { MuiSvgIconStyleOverrides } from '../SvgIcon';
 import { MuiSwitchStyleOverrides } from '../Switch';
 import { TagClassKey } from '../Tag';
 import { MuiTypographyStyleOverrides, TypographyClassKey } from '../Typography';
+import { MuiListItemSecondaryActionStyleOverrides } from '../ListItemSecondaryAction';
 
 declare module '@material-ui/core/styles/overrides' {
   interface ComponentNameToClassKey {
@@ -74,6 +75,7 @@ const overrides = (theme: Theme): Overrides => ({
   MuiListItemAvatar: MuiListItemAvatarStyleOverrides,
   MuiListItemIcon: MuiListItemIconStyleOverrides(theme),
   MuiListItemText: MuiListItemTextStyleOverrides(theme),
+  MuiListItemSecondaryAction: MuiListItemSecondaryActionStyleOverrides,
   MuiListSubheader: MuiListSubheaderStyleOverrides(theme),
   MuiMenu: MuiMenuStyleOverrides(theme),
   MuiMenuItem: MuiMenuItemStyleOverrides(theme),

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -31,6 +31,7 @@ import { MuiPaginationItemStyleOverrides } from '../PaginationItem';
 import { MuiRadioStyleOverrides } from '../Radio';
 import { MuiSelectStylesOverrides } from '../Select';
 import { MuiSvgIconStyleOverrides } from '../SvgIcon';
+import { MuiSwitchStyleOverrides } from '../Switch';
 import { TagClassKey } from '../Tag';
 import { MuiTypographyStyleOverrides, TypographyClassKey } from '../Typography';
 
@@ -81,6 +82,7 @@ const overrides = (theme: Theme): Overrides => ({
   MuiRadio: MuiRadioStyleOverrides(theme),
   MuiSelect: MuiSelectStylesOverrides(theme),
   MuiSvgIcon: MuiSvgIconStyleOverrides(theme),
+  MuiSwitch: MuiSwitchStyleOverrides(theme),
   MuiTypography: MuiTypographyStyleOverrides,
 });
 

--- a/libs/spark/stories/switch.stories.tsx
+++ b/libs/spark/stories/switch.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Switch, FormControlLabel } from '../src';
+import { ChangelogTemplate } from './changelog-template';
+import { DocTemplate } from './documentation-template';
 
 export default {
   title: 'prenda-spark/Switch',
@@ -264,3 +266,53 @@ LabeledStatesHover.parameters = { pseudo: { hover: true } };
 
 export const LabeledStatesFocus = PseudoLabeledStatesTemplate.bind({});
 LabeledStatesFocus.parameters = { pseudo: { focus: true } };
+
+const SwitchDocTemplate = (args) => <DocTemplate {...args} />;
+
+export const Documentation: Story = SwitchDocTemplate.bind({});
+Documentation.args = {
+  underlyingComponent: {
+    name: 'Switch',
+    href: 'https://v4.mui.com/components/switches',
+  },
+  props: {
+    extends: {
+      href: 'https://v4.mui.com/api/switch/#props',
+    },
+    omits: [
+      {
+        name: 'color',
+        defaultValue: "'default'",
+      },
+      {
+        name: 'size',
+        defaultValue: "'small'",
+      },
+    ],
+    adds: [
+      {
+        name: 'size',
+        type: "'small' | 'large'",
+        defaultValue: "'small'",
+      },
+    ],
+  },
+  css: {
+    extends: {
+      href: 'https://v4.mui.com/api/switch/#css',
+    },
+  },
+};
+
+const SwitchChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
+
+export const Changelog: Story = SwitchChangelogTemplate.bind({});
+Changelog.args = {
+  history: [
+    {
+      version: 'vNext',
+      versionDate: 'yyyy-mm-dd',
+      changes: ['Initial implementation.'],
+    },
+  ],
+};

--- a/libs/spark/stories/switch.stories.tsx
+++ b/libs/spark/stories/switch.stories.tsx
@@ -42,9 +42,16 @@ const Template: Story = (args) => (
 
 export const Configurable = Template.bind({});
 
+const Container = styled('div')({
+  display: 'flex',
+  gap: '1rem',
+  margin: '1rem',
+  width: 'min-content',
+});
+
 const StatesTemplate: Story = () => (
   <>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    <Container>
       <Switch
         name="nameA"
         value="valueA"
@@ -69,8 +76,8 @@ const StatesTemplate: Story = () => (
         checked
         disabled
       />
-    </div>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    </Container>
+    <Container>
       <Switch
         name="nameA"
         value="valueA"
@@ -99,13 +106,13 @@ const StatesTemplate: Story = () => (
         checked
         disabled
       />
-    </div>
+    </Container>
   </>
 );
 
 const PseudoStatesTemplate: Story = () => (
   <>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    <Container>
       <Switch
         name="nameA"
         value="valueA"
@@ -117,8 +124,8 @@ const PseudoStatesTemplate: Story = () => (
         inputProps={{ 'aria-label': 'Name B' }}
         checked
       />
-    </div>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    </Container>
+    <Container>
       <Switch
         name="nameA"
         value="valueA"
@@ -132,7 +139,7 @@ const PseudoStatesTemplate: Story = () => (
         size="large"
         checked
       />
-    </div>
+    </Container>
   </>
 );
 
@@ -146,13 +153,13 @@ StatesFocus.parameters = { pseudo: { focus: true } };
 
 const LabeledStatesTemplate: Story = () => (
   <>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    <Container>
       <FormControlLabel label="Label" control={<Switch />} />
       <FormControlLabel label="Label" control={<Switch />} disabled />
       <FormControlLabel label="Label" control={<Switch checked />} />
       <FormControlLabel label="Label" control={<Switch checked />} disabled />
-    </div>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    </Container>
+    <Container>
       <FormControlLabel label="Label" control={<Switch size="large" />} />
       <FormControlLabel
         label="Label"
@@ -168,8 +175,8 @@ const LabeledStatesTemplate: Story = () => (
         control={<Switch size="large" checked />}
         disabled
       />
-    </div>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    </Container>
+    <Container>
       <FormControlLabel
         label="Label"
         labelPlacement="start"
@@ -192,8 +199,8 @@ const LabeledStatesTemplate: Story = () => (
         control={<Switch checked />}
         disabled
       />
-    </div>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    </Container>
+    <Container>
       <FormControlLabel
         label="Label"
         labelPlacement="start"
@@ -216,17 +223,17 @@ const LabeledStatesTemplate: Story = () => (
         control={<Switch size="large" checked />}
         disabled
       />
-    </div>
+    </Container>
   </>
 );
 
 const PseudoLabeledStatesTemplate: Story = (args) => (
   <>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    <Container>
       <FormControlLabel label="Label" control={<Switch />} {...args} />
       <FormControlLabel label="Label" control={<Switch checked />} {...args} />
-    </div>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    </Container>
+    <Container>
       <FormControlLabel
         label="Label"
         control={<Switch size="large" />}
@@ -237,8 +244,8 @@ const PseudoLabeledStatesTemplate: Story = (args) => (
         control={<Switch size="large" checked />}
         {...args}
       />
-    </div>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    </Container>
+    <Container>
       <FormControlLabel
         label="Label"
         labelPlacement="start"
@@ -251,8 +258,8 @@ const PseudoLabeledStatesTemplate: Story = (args) => (
         control={<Switch checked />}
         {...args}
       />
-    </div>
-    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    </Container>
+    <Container>
       <FormControlLabel
         label="Label"
         labelPlacement="start"
@@ -265,7 +272,7 @@ const PseudoLabeledStatesTemplate: Story = (args) => (
         control={<Switch size="large" checked />}
         {...args}
       />
-    </div>
+    </Container>
   </>
 );
 
@@ -306,7 +313,8 @@ const RightAlignedListItemText = withStyles({
 })(ListItemText);
 
 const LabeledInListTemplate: Story = (args) => (
-  <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+  // `width: min-content` will shrink the cards, so set 2 card widths + gap.
+  <Container style={{ width: 256 * 2 + 16 }}>
     <CustomCard>
       <List disablePadding>
         <PaddedListItem divider disableGutters>
@@ -384,7 +392,7 @@ const LabeledInListTemplate: Story = (args) => (
         </PaddedListItem>
       </List>
     </CustomCard>
-  </div>
+  </Container>
 );
 
 export const LabeledInList = LabeledInListTemplate.bind({});

--- a/libs/spark/stories/switch.stories.tsx
+++ b/libs/spark/stories/switch.stories.tsx
@@ -1,6 +1,16 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { Switch, FormControlLabel } from '../src';
+import {
+  Switch,
+  FormControlLabel,
+  Card,
+  ListItem,
+  ListItemText,
+  List,
+  withStyles,
+  ListItemIcon,
+  styled,
+} from '../src';
 import { ChangelogTemplate } from './changelog-template';
 import { DocTemplate } from './documentation-template';
 
@@ -266,6 +276,118 @@ LabeledStatesHover.parameters = { pseudo: { hover: true } };
 
 export const LabeledStatesFocus = PseudoLabeledStatesTemplate.bind({});
 LabeledStatesFocus.parameters = { pseudo: { focus: true } };
+
+const CustomCard = withStyles({
+  root: {
+    maxWidth: 256,
+    width: '100%',
+    padding: '0 16px',
+  },
+})(Card);
+
+const PaddedListItem = withStyles({
+  root: {
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  // without cast, TS infers wrong props signature
+})(ListItem) as typeof ListItem;
+
+const ListItemEndIcon = styled('div')(({ theme }) => ({
+  color: theme.palette.action.active,
+  flexShrink: 0,
+  display: 'inline-flex',
+}));
+
+const RightAlignedListItemText = withStyles({
+  root: {
+    textAlign: 'right',
+  },
+})(ListItemText);
+
+const LabeledInListTemplate: Story = (args) => (
+  <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+    <CustomCard>
+      <List disablePadding>
+        <PaddedListItem divider disableGutters>
+          <ListItemText id="switch-list-label-1" primary="List label" />
+          <ListItemEndIcon>
+            <Switch
+              edge="end"
+              inputProps={{ 'aria-labelledby': 'switch-list-label-1' }}
+              {...args}
+            />
+          </ListItemEndIcon>
+        </PaddedListItem>
+        <PaddedListItem divider disableGutters>
+          <ListItemText id="switch-list-label-2" primary="List label" />
+          <ListItemEndIcon>
+            <Switch
+              edge="end"
+              inputProps={{ 'aria-labelledby': 'switch-list-label-2' }}
+              {...args}
+            />
+          </ListItemEndIcon>
+        </PaddedListItem>
+        <PaddedListItem disableGutters>
+          <ListItemText id="switch-list-label-3" primary="List label" />
+          <ListItemEndIcon>
+            <Switch
+              edge="end"
+              inputProps={{ 'aria-labelledby': 'switch-list-label-3' }}
+              {...args}
+            />
+          </ListItemEndIcon>
+        </PaddedListItem>
+      </List>
+    </CustomCard>
+    <CustomCard>
+      <List disablePadding>
+        <PaddedListItem divider disableGutters>
+          <ListItemIcon>
+            <Switch
+              edge="start"
+              inputProps={{ 'aria-labelledby': 'switch-list-label-4' }}
+              {...args}
+            />
+          </ListItemIcon>
+          <RightAlignedListItemText
+            id="switch-list-label-4"
+            primary="List label"
+          />
+        </PaddedListItem>
+        <PaddedListItem divider disableGutters>
+          <ListItemIcon>
+            <Switch
+              edge="start"
+              inputProps={{ 'aria-labelledby': 'switch-list-label-5' }}
+              {...args}
+            />
+          </ListItemIcon>
+          <RightAlignedListItemText
+            id="switch-list-label-5"
+            primary="List label"
+          />
+        </PaddedListItem>
+        <PaddedListItem disableGutters>
+          <ListItemIcon>
+            <Switch
+              edge="start"
+              inputProps={{ 'aria-labelledby': 'switch-list-label-6' }}
+              {...args}
+            />
+          </ListItemIcon>
+          <RightAlignedListItemText
+            id="switch-list-label-6"
+            primary="List label"
+          />
+        </PaddedListItem>
+      </List>
+    </CustomCard>
+  </div>
+);
+
+export const LabeledInList = LabeledInListTemplate.bind({});
 
 const SwitchDocTemplate = (args) => <DocTemplate {...args} />;
 

--- a/libs/spark/stories/switch.stories.tsx
+++ b/libs/spark/stories/switch.stories.tsx
@@ -1,0 +1,266 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { Switch, FormControlLabel } from '../src';
+
+export default {
+  title: 'prenda-spark/Switch',
+  component: Switch,
+  parameters: { actions: { handles: ['change'] } },
+  argTypes: {
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    size: { control: 'select', options: ['large', 'small'] },
+  },
+  args: {
+    checked: false,
+    disabled: false,
+    size: 'small',
+  },
+} as Meta;
+
+const Template: Story = (args) => (
+  <Switch
+    // a11y required props when there's no label
+    name="Demo"
+    value="value"
+    inputProps={{ 'aria-label': 'Value' }}
+    {...args}
+  />
+);
+
+export const Configurable = Template.bind({});
+
+const StatesTemplate: Story = () => (
+  <>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <Switch
+        name="nameA"
+        value="valueA"
+        inputProps={{ 'aria-label': 'Name A' }}
+      />
+      <Switch
+        name="nameB"
+        value="valueB"
+        inputProps={{ 'aria-label': 'Name B' }}
+        disabled
+      />
+      <Switch
+        name="nameC"
+        value="valueC"
+        inputProps={{ 'aria-label': 'Name C' }}
+        checked
+      />
+      <Switch
+        name="nameD"
+        value="valueD"
+        inputProps={{ 'aria-label': 'Name D' }}
+        checked
+        disabled
+      />
+    </div>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <Switch
+        name="nameA"
+        value="valueA"
+        inputProps={{ 'aria-label': 'Name A' }}
+        size="large"
+      />
+      <Switch
+        name="nameB"
+        value="valueB"
+        inputProps={{ 'aria-label': 'Name B' }}
+        size="large"
+        disabled
+      />
+      <Switch
+        name="nameC"
+        value="valueC"
+        inputProps={{ 'aria-label': 'Name C' }}
+        size="large"
+        checked
+      />
+      <Switch
+        name="nameD"
+        value="valueD"
+        inputProps={{ 'aria-label': 'Name D' }}
+        size="large"
+        checked
+        disabled
+      />
+    </div>
+  </>
+);
+
+const PseudoStatesTemplate: Story = () => (
+  <>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <Switch
+        name="nameA"
+        value="valueA"
+        inputProps={{ 'aria-label': 'Name A' }}
+      />
+      <Switch
+        name="nameB"
+        value="valueB"
+        inputProps={{ 'aria-label': 'Name B' }}
+        checked
+      />
+    </div>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <Switch
+        name="nameA"
+        value="valueA"
+        inputProps={{ 'aria-label': 'Name A' }}
+        size="large"
+      />
+      <Switch
+        name="nameB"
+        value="valueB"
+        inputProps={{ 'aria-label': 'Name B' }}
+        size="large"
+        checked
+      />
+    </div>
+  </>
+);
+
+export const States = StatesTemplate.bind({});
+
+export const StatesHover = PseudoStatesTemplate.bind({});
+StatesHover.parameters = { pseudo: { hover: true } };
+
+export const StatesFocus = PseudoStatesTemplate.bind({});
+StatesFocus.parameters = { pseudo: { focus: true } };
+
+const LabeledStatesTemplate: Story = () => (
+  <>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <FormControlLabel label="Label" control={<Switch />} />
+      <FormControlLabel label="Label" control={<Switch />} disabled />
+      <FormControlLabel label="Label" control={<Switch checked />} />
+      <FormControlLabel label="Label" control={<Switch checked />} disabled />
+    </div>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <FormControlLabel label="Label" control={<Switch size="large" />} />
+      <FormControlLabel
+        label="Label"
+        control={<Switch size="large" />}
+        disabled
+      />
+      <FormControlLabel
+        label="Label"
+        control={<Switch size="large" checked />}
+      />
+      <FormControlLabel
+        label="Label"
+        control={<Switch size="large" checked />}
+        disabled
+      />
+    </div>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch />}
+      />
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch />}
+        disabled
+      />
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch checked />}
+      />
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch checked />}
+        disabled
+      />
+    </div>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch size="large" />}
+      />
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch size="large" />}
+        disabled
+      />
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch size="large" checked />}
+      />
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch size="large" checked />}
+        disabled
+      />
+    </div>
+  </>
+);
+
+const PseudoLabeledStatesTemplate: Story = (args) => (
+  <>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <FormControlLabel label="Label" control={<Switch />} {...args} />
+      <FormControlLabel label="Label" control={<Switch checked />} {...args} />
+    </div>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <FormControlLabel
+        label="Label"
+        control={<Switch size="large" />}
+        {...args}
+      />
+      <FormControlLabel
+        label="Label"
+        control={<Switch size="large" checked />}
+        {...args}
+      />
+    </div>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch />}
+        {...args}
+      />
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch checked />}
+        {...args}
+      />
+    </div>
+    <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch size="large" />}
+        {...args}
+      />
+      <FormControlLabel
+        label="Label"
+        labelPlacement="start"
+        control={<Switch size="large" checked />}
+        {...args}
+      />
+    </div>
+  </>
+);
+
+export const LabeledStates = LabeledStatesTemplate.bind({});
+
+export const LabeledStatesHover = PseudoLabeledStatesTemplate.bind({});
+LabeledStatesHover.parameters = { pseudo: { hover: true } };
+
+export const LabeledStatesFocus = PseudoLabeledStatesTemplate.bind({});
+LabeledStatesFocus.parameters = { pseudo: { focus: true } };


### PR DESCRIPTION
Closes #147 

Also adds re-exports of `List` and `ListItemSecondaryAction`. I initially used the latter to right-align the `Switch` element in the "Labeled in List" story, however it absolutely positions its children, taking them out of the layout calculation. Thus, you'd have to explicitly account for whether the Switch is `size="small"` or `size="large"`... bad news bears. Instead, the `ListItemIcon` component is much more straightforward, and I copied the relevant styles of that for the story-internal component `ListItemEndIcon`.