### PR TITLE
feat(Tabs): initial implementation

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -13,24 +13,26 @@
 - **IconButton**
   - Forwards ref.
 - **List**
-  - Added re-export.
-  - Added minimal styling.
+  - Re-exported.
+  - Customized styling.
 - **ListItemSecondaryAction**
-  - Added re-export.
-  - Added minimal styling.
+  - Re-exported.
+  - Customized styling.
 - **Switch**
   - Initial implementation.
 - **Tab**
-  - Initial implementation.
+  - Re-exported.
+  - Customized styling.
 - **TabContext**
-  - Added re-export.
+  - Re-exported.
 - **TabList**
-  - Added re-export.
+  - Re-exported.
 - **TabPanel**
-  - Added re-export.
+  - Re-exported.
+  - Customized styling.
 - **Tabs**
-  - Added re-export.
-  - Added minimal default props and styling.
+  - Re-exported.
+  - Customized default props and styling.
 
 ### Fixes
 
@@ -95,35 +97,35 @@
 ### Features
 
 - **Autocomplete**
-  - Added re-export.
+  - Re-exported.
   - Added initial styling support: multiple Checkboxes.
 - **Avatar**
   - Initial implementation.
 - **Card**
   - Updated elevation (design change).
 - **Divider**
-  - Added re-export.
+  - Re-exported.
   - Added minimal styling related to **MenuList** styling support.
 - **Input**
   - See **InputBase**.
 - **InputBase**
   - Added styling for `startAdornment` and `endAdornment` props.
 - **List**
-  - Added re-export.
+  - Re-exported.
   - Added minimal styling related to **MenuList** styling support.
 - **ListItem**
   - Added minimal styling related to **MenuItem** styling support.
 - **ListItemAvatar**
-  - Added re-export.
+  - Re-exported.
   - Added minimal styling related to **MenuItem** styling support.
 - **ListItemIcon**
-  - Added re-export.
+  - Re-exported.
   - Added minimal styling related to **MenuItem** styling support.
 - **ListItemText**
-  - Added re-export.
+  - Re-exported.
   - Added minimal styling related to **MenuItem** styling support.
 - **ListSubheader**
-  - Added re-export.
+  - Re-exported.
   - Added minimal styling related to **MenuList** styling support.
 - **Menu**
   - Updated elevation (design change).
@@ -132,10 +134,10 @@
   - Added styling for content: `ListItemText`, `ListItemIcon`, `ListItemAvatar`, `ListItem`
   - Added styling when prop `selected` is `true`.
 - **MenuList**
-  - Added re-export.
+  - Re-exported.
   - Confirmed styling.
 - **Paper**
-  - Added re-export.
+  - Re-exported.
   - Added minimal styling related to **MenuList** styling support.
 - **Select**
   - See **InputBase**.

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -20,6 +20,17 @@
   - Added minimal styling.
 - **Switch**
   - Initial implementation.
+- **Tab**
+  - Initial implementation.
+- **TabContext**
+  - Added re-export.
+- **TabList**
+  - Added re-export.
+- **TabPanel**
+  - Added re-export.
+- **Tabs**
+  - Added re-export.
+  - Added minimal default props and styling.
 
 ### Fixes
 

--- a/libs/spark/src/Tab.ts
+++ b/libs/spark/src/Tab.ts
@@ -1,0 +1,47 @@
+import type {
+  StyleRules,
+  TabClassKey,
+  TabProps,
+  Theme,
+} from '@material-ui/core';
+import Tab from '@material-ui/core/Tab';
+
+export default Tab;
+
+export type { TabProps };
+
+// :NOTE: the focus styling is implemented with a border. To prevent layout
+// shifts when that is applied, a border is always present on the root element.
+// Property value calculations with "... - 2" are explicitly taking that into
+// account where the "..." value is more reflective of the design measurement
+// than the raw sum would be.
+export const MuiTabStyleOverrides = ({
+  palette,
+  typography,
+}: Theme): Partial<StyleRules<TabClassKey>> => ({
+  root: {
+    ...typography['label-xl-strong'],
+    color: palette.text.onLightLowContrast,
+    borderColor: 'transparent',
+    borderStyle: 'solid',
+    borderRadius: 8,
+    borderWidth: 2,
+    padding: `${16 - 2}px 0`,
+    '&:hover': {
+      color: palette.text.onLight,
+    },
+    '&:focus': {
+      color: palette.text.onLight,
+      borderColor: palette.blue[1],
+    },
+    '&:active': {
+      color: palette.text.onLight,
+    },
+    '&$selected': {
+      color: palette.text.onLight,
+    },
+    '&$disabled': {
+      color: palette.grey.medium,
+    },
+  },
+});

--- a/libs/spark/src/Tab.ts
+++ b/libs/spark/src/Tab.ts
@@ -16,23 +16,32 @@ export type { TabProps };
 // account where the "..." value is more reflective of the design measurement
 // than the raw sum would be.
 export const MuiTabStyleOverrides = ({
+  breakpoints,
   palette,
   typography,
 }: Theme): Partial<StyleRules<TabClassKey>> => ({
   root: {
     ...typography['label-xl-strong'],
-    color: palette.text.onLightLowContrast,
     borderColor: 'transparent',
     borderStyle: 'solid',
     borderRadius: 8,
     borderWidth: 2,
     padding: `${16 - 2}px 0`,
+    '&:focus': {
+      borderColor: palette.blue[1],
+    },
+    // reset Mui default
+    [breakpoints.up('sm')]: {
+      minWidth: 'unset',
+    },
+  },
+  textColorPrimary: {
+    color: palette.text.onLightLowContrast,
     '&:hover': {
       color: palette.text.onLight,
     },
     '&:focus': {
       color: palette.text.onLight,
-      borderColor: palette.blue[1],
     },
     '&:active': {
       color: palette.text.onLight,

--- a/libs/spark/src/TabContext.ts
+++ b/libs/spark/src/TabContext.ts
@@ -1,0 +1,6 @@
+import type { TabContextProps } from '@material-ui/lab';
+import TabContext from '@material-ui/lab/TabContext';
+
+export default TabContext;
+
+export type { TabContextProps };

--- a/libs/spark/src/TabList.ts
+++ b/libs/spark/src/TabList.ts
@@ -1,0 +1,6 @@
+import type { TabListProps } from '@material-ui/lab';
+import TabList from '@material-ui/lab/TabList';
+
+export default TabList;
+
+export type { TabListProps };

--- a/libs/spark/src/TabPanel.ts
+++ b/libs/spark/src/TabPanel.ts
@@ -1,0 +1,6 @@
+import type { TabPanelProps } from '@material-ui/lab';
+import TabPanel from '@material-ui/lab/TabPanel';
+
+export default TabPanel;
+
+export type { TabPanelProps };

--- a/libs/spark/src/TabPanel.ts
+++ b/libs/spark/src/TabPanel.ts
@@ -4,3 +4,9 @@ import TabPanel from '@material-ui/lab/TabPanel';
 export default TabPanel;
 
 export type { TabPanelProps };
+
+export const MuiTabPanelStyleOverrides = {
+  root: {
+    padding: 0,
+  },
+};

--- a/libs/spark/src/Tabs.ts
+++ b/libs/spark/src/Tabs.ts
@@ -1,0 +1,23 @@
+import type { TabsProps, Theme } from '@material-ui/core';
+import Tabs from '@material-ui/core/Tabs';
+
+export default Tabs;
+
+export type { TabsProps };
+
+export const MuiTabsDefaultProps = {
+  indicatorColor: 'primary' as const,
+  textColor: 'primary' as const,
+};
+
+export const MuiTabsStyleOverrides = ({ palette }: Theme) => ({
+  root: {
+    boxShadow: `inset 0 -2px ${palette.grey.medium}`,
+  },
+  flexContainer: {
+    gap: 24,
+  },
+  indicator: {
+    backgroundColor: palette.blue[3],
+  },
+});

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -126,6 +126,9 @@ export * from './SvgIcon';
 export { default as Switch } from './Switch';
 export * from './Switch';
 
+export { default as Tab } from './Tab';
+export * from './Tab';
+
 export { default as Tag } from './Tag';
 export * from './Tag';
 

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -129,6 +129,18 @@ export * from './Switch';
 export { default as Tab } from './Tab';
 export * from './Tab';
 
+export { default as TabContext } from './TabContext';
+export * from './TabContext';
+
+export { default as TabList } from './TabList';
+export * from './TabList';
+
+export { default as TabPanel } from './TabPanel';
+export * from './TabPanel';
+
+export { default as Tabs } from './Tabs';
+export * from './Tabs';
+
 export { default as Tag } from './Tag';
 export * from './Tag';
 

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -33,6 +33,7 @@ import { MuiSelectStylesOverrides } from '../Select';
 import { MuiSvgIconStyleOverrides } from '../SvgIcon';
 import { MuiSwitchStyleOverrides } from '../Switch';
 import { MuiTabStyleOverrides } from '../Tab';
+import { MuiTabsStyleOverrides } from '../Tabs';
 import { TagClassKey } from '../Tag';
 import { MuiTypographyStyleOverrides, TypographyClassKey } from '../Typography';
 import { MuiListItemSecondaryActionStyleOverrides } from '../ListItemSecondaryAction';
@@ -87,6 +88,7 @@ const overrides = (theme: Theme): Overrides => ({
   MuiSvgIcon: MuiSvgIconStyleOverrides(theme),
   MuiSwitch: MuiSwitchStyleOverrides(theme),
   MuiTab: MuiTabStyleOverrides(theme),
+  MuiTabs: MuiTabsStyleOverrides(theme),
   MuiTypography: MuiTypographyStyleOverrides,
 });
 

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -32,6 +32,7 @@ import { MuiRadioStyleOverrides } from '../Radio';
 import { MuiSelectStylesOverrides } from '../Select';
 import { MuiSvgIconStyleOverrides } from '../SvgIcon';
 import { MuiSwitchStyleOverrides } from '../Switch';
+import { MuiTabStyleOverrides } from '../Tab';
 import { TagClassKey } from '../Tag';
 import { MuiTypographyStyleOverrides, TypographyClassKey } from '../Typography';
 import { MuiListItemSecondaryActionStyleOverrides } from '../ListItemSecondaryAction';
@@ -85,6 +86,7 @@ const overrides = (theme: Theme): Overrides => ({
   MuiSelect: MuiSelectStylesOverrides(theme),
   MuiSvgIcon: MuiSvgIconStyleOverrides(theme),
   MuiSwitch: MuiSwitchStyleOverrides(theme),
+  MuiTab: MuiTabStyleOverrides(theme),
   MuiTypography: MuiTypographyStyleOverrides,
 });
 

--- a/libs/spark/src/styles/overrides.ts
+++ b/libs/spark/src/styles/overrides.ts
@@ -34,6 +34,7 @@ import { MuiSvgIconStyleOverrides } from '../SvgIcon';
 import { MuiSwitchStyleOverrides } from '../Switch';
 import { MuiTabStyleOverrides } from '../Tab';
 import { MuiTabsStyleOverrides } from '../Tabs';
+import { MuiTabPanelStyleOverrides } from '../TabPanel';
 import { TagClassKey } from '../Tag';
 import { MuiTypographyStyleOverrides, TypographyClassKey } from '../Typography';
 import { MuiListItemSecondaryActionStyleOverrides } from '../ListItemSecondaryAction';
@@ -88,6 +89,7 @@ const overrides = (theme: Theme): Overrides => ({
   MuiSvgIcon: MuiSvgIconStyleOverrides(theme),
   MuiSwitch: MuiSwitchStyleOverrides(theme),
   MuiTab: MuiTabStyleOverrides(theme),
+  MuiTabPanel: MuiTabPanelStyleOverrides,
   MuiTabs: MuiTabsStyleOverrides(theme),
   MuiTypography: MuiTypographyStyleOverrides,
 });

--- a/libs/spark/src/styles/props.ts
+++ b/libs/spark/src/styles/props.ts
@@ -1,4 +1,4 @@
-import { MuiAutocompleteDefaultProps } from '..';
+import { MuiAutocompleteDefaultProps } from '../Autocomplete';
 import { MuiButtonDefaultProps } from '../Button';
 import { MuiButtonBaseDefaultProps } from '../ButtonBase';
 import { MuiCardDefaultProps } from '../Card';
@@ -11,6 +11,7 @@ import { MuiPaginationDefaultProps } from '../Pagination';
 import { MuiPaginationItemDefaultProps } from '../PaginationItem';
 import { MuiRadioDefaultProps } from '../Radio';
 import { MuiSelectDefaultProps } from '../Select';
+import { MuiTabsDefaultProps } from '../Tabs';
 
 const props = {
   MuiAutocomplete: MuiAutocompleteDefaultProps,
@@ -26,6 +27,7 @@ const props = {
   MuiPaginationItem: MuiPaginationItemDefaultProps,
   MuiRadio: MuiRadioDefaultProps,
   MuiSelect: MuiSelectDefaultProps,
+  MuiTabs: MuiTabsDefaultProps,
 };
 
 export default props;

--- a/libs/spark/stories/tab.stories.tsx
+++ b/libs/spark/stories/tab.stories.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { Tab, styled } from '../src';
+import { ChangelogTemplate } from './changelog-template';
+import { DocTemplate } from './documentation-template';
+
+export default {
+  title: 'prenda-spark/Tab',
+  component: Tab,
+  argTypes: {
+    disabled: { control: 'boolean' },
+    label: { control: 'text' },
+    onClick: { actions: 'clicked' },
+    selected: { control: 'boolean' },
+    value: { control: 'text' },
+  },
+  args: {
+    label: 'Label',
+    value: 'value',
+    disabled: false,
+    selected: false,
+  },
+} as Meta;
+
+const Template: Story = (args) => <Tab {...args} />;
+
+export const Configurable = Template.bind({});
+
+const Container = styled('div')({
+  display: 'flex',
+  gap: '1rem',
+  margin: '1rem',
+  width: 'min-content',
+});
+
+const StatesTemplate = (args) => (
+  <Container>
+    <Tab {...args} />
+    <Tab {...args} selected />
+  </Container>
+);
+
+export const States = StatesTemplate.bind({});
+
+export const StatesDisabled = StatesTemplate.bind({});
+StatesDisabled.args = { disabled: true };
+
+export const StatesHover = StatesTemplate.bind({});
+StatesHover.parameters = { pseudo: { hover: true } };
+
+export const StatesFocus = StatesTemplate.bind({});
+StatesFocus.parameters = { pseudo: { focus: true } };
+
+export const StatesActive = StatesTemplate.bind({});
+StatesActive.parameters = { pseudo: { active: true } };
+
+const TabDocTemplate = (args) => <DocTemplate {...args} />;
+
+export const Documentation: Story = TabDocTemplate.bind({});
+Documentation.args = {
+  underlyingComponent: {
+    name: 'Tab',
+    href: 'https://v4.mui.com/components/tabs',
+  },
+  props: {
+    extends: {
+      href: 'https://v4.mui.com/api/tab/#props',
+    },
+  },
+  css: {
+    extends: {
+      href: 'https://v4.mui.com/api/tab/#css',
+    },
+  },
+};
+
+const TabChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
+
+export const Changelog: Story = TabChangelogTemplate.bind({});
+Changelog.args = {
+  history: [
+    {
+      version: 'vNext',
+      versionDate: 'yyyy-mm-dd',
+      changes: ['Feat: Initial implementation.'],
+    },
+  ],
+};

--- a/libs/spark/stories/tab.stories.tsx
+++ b/libs/spark/stories/tab.stories.tsx
@@ -19,6 +19,9 @@ export default {
     value: 'value',
     disabled: false,
     selected: false,
+    // not a public prop, but in absense of Tab being a child of Tabs, we
+    // should explicitly set it
+    textColor: 'primary',
   },
 } as Meta;
 

--- a/libs/spark/stories/tabs.stories.tsx
+++ b/libs/spark/stories/tabs.stories.tsx
@@ -45,10 +45,18 @@ const Template: Story = (args) => {
           <Tab value="value-3" label="Label" />
           <Tab value="value-4" label="Label" />
         </TabList>
-        <TabPanel value="value-1">Panel 1</TabPanel>
-        <TabPanel value="value-2">Panel 2</TabPanel>
-        <TabPanel value="value-3">Panel 3</TabPanel>
-        <TabPanel value="value-4">Panel 4</TabPanel>
+        <TabPanel value="value-1">
+          <Box pt={1}>Panel 1</Box>
+        </TabPanel>
+        <TabPanel value="value-2">
+          <Box pt={1}>Panel 2</Box>
+        </TabPanel>
+        <TabPanel value="value-3">
+          <Box pt={1}>Panel 3</Box>
+        </TabPanel>
+        <TabPanel value="value-4">
+          <Box pt={1}>Panel 4</Box>
+        </TabPanel>
       </TabContext>
 
       <Box mt={4}>

--- a/libs/spark/stories/tabs.stories.tsx
+++ b/libs/spark/stories/tabs.stories.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  Box,
+  Tab,
+  TabContext,
+  TabList,
+  TabPanel,
+  Typography,
+  withStyles,
+} from '../src';
+import { ChangelogTemplate } from './changelog-template';
+import { DocTemplate } from './documentation-template';
+
+export default {
+  title: 'prenda-spark/TabList',
+  component: TabList,
+  argTypes: {
+    'aria-label': { control: 'text' },
+    onChange: { actions: 'changed' },
+    value: {
+      control: 'select',
+      options: ['value-1', 'value-2', 'value-3', 'value-4'],
+    },
+  },
+  args: {
+    'aria-label': 'tabs story',
+    value: 'value-1',
+  },
+} as Meta;
+
+const CodeSnippet = withStyles({
+  root: { display: 'inline' },
+})((props) => <Typography variant="code-md" {...props} />);
+
+const Template: Story = (args) => {
+  const [value, setValue] = React.useState(args.value);
+
+  return (
+    <>
+      <TabContext value={value}>
+        <TabList {...args} onChange={(event, newValue) => setValue(newValue)}>
+          <Tab value="value-1" label="Label" />
+          <Tab value="value-2" label="Label" />
+          <Tab value="value-3" label="Label" />
+          <Tab value="value-4" label="Label" />
+        </TabList>
+        <TabPanel value="value-1">Panel 1</TabPanel>
+        <TabPanel value="value-2">Panel 2</TabPanel>
+        <TabPanel value="value-3">Panel 3</TabPanel>
+        <TabPanel value="value-4">Panel 4</TabPanel>
+      </TabContext>
+
+      <Box mt={4}>
+        <Typography component="span" variant="paragraph-lg">
+          <strong>Note:</strong> It is <em>highly</em> recommended to use{' '}
+          <CodeSnippet>{'<TabList>'}</CodeSnippet> (with{' '}
+          <CodeSnippet>{'<TabContext>'}</CodeSnippet> and{' '}
+          <CodeSnippet>{'<TabPanel>'}</CodeSnippet>) instead of{' '}
+          <CodeSnippet>{'<Tabs>'}</CodeSnippet> because of the built-in
+          accessibility handling.
+        </Typography>
+      </Box>
+    </>
+  );
+};
+
+export const Configurable = Template.bind({});
+Configurable.decorators = [(Story) => <Story />];
+
+const TabDocTemplate = (args) => <DocTemplate {...args} />;
+
+export const Documentation: Story = TabDocTemplate.bind({});
+Documentation.args = {
+  underlyingComponent: {
+    name: 'TabList (Tabs)',
+    href: 'https://v4.mui.com/components/tabs/#accessibility',
+  },
+  props: {
+    extends: {
+      href: 'https://v4.mui.com/api/tab-list/#props',
+    },
+  },
+  css: {
+    extends: {
+      href: 'https://v4.mui.com/api/tab-list/#css',
+    },
+  },
+};
+
+const TabChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
+
+export const Changelog: Story = TabChangelogTemplate.bind({});
+Changelog.args = {
+  history: [
+    {
+      version: 'vNext',
+      versionDate: 'yyyy-mm-dd',
+      changes: ['Feat: Initial implementation.'],
+    },
+  ],
+};


### PR DESCRIPTION
Closes #148 

Re-exports / customizes the core `Tab`, `Tabs` and the experimental `TabContext`, `TabList`, `TabPanel`. The latter of which are emphasized for exclusive use because of their built-in accessibility handling when used as a trio. This is hard to communicate/separate in the story layout, documentation, etc, so I just added a note.