### PR TITLE
chore: implement common build process for icons and components

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,18 +18,28 @@ jobs:
         with:
           node-version: '14'
 
-      - run: npm ci
-      - run: npx nx run spark:test
-      - run: npx nx run spark-e2e:e2e
+      - name: Clean install
+        run: npm ci
+
+      - name: Test
+        run: npx nx run spark:test && npx nx run spark-e2e:e2e
+
       # stories & tests depend on @prenda/spark-icons, but aren't included in build
-      #  without this, Nx prevents build and requires icons be built first (circular dep)
-      - run: rm -rf ./libs/spark/stories ./libs/spark/test
-      - run: npx nx run spark:build
-      - uses: JS-DevTools/npm-publish@v1
+      #  without this, Nx prevents build and requires icons be built first
+      #  (false positive on circular dep)
+      - name: Strip directories
+        run: rm -rf ./libs/spark/stories ./libs/spark/test
+
+      - name: Build @prenda/spark
+        run: npm run build:components
+
+      - name: Publish @prenda/spark
+        uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./dist/libs/spark/package.json
-      - name: Slack Notification Success
+
+      - name: Notify Slack about success
         if: success()
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -39,9 +49,10 @@ jobs:
           SLACK_ICON: https://github.com/prenda-school/prenda-spark/raw/main/public/img/spark-logo-multicolor-darker.svg
           SLACK_USERNAME: 'Action: NPM Publish'
           MSG_MINIMAL: true
-          SLACK_TITLE: '@prenda/spark'
+          SLACK_TITLE: '@prenda/spark ${{ env.GITHUB_REF }}'
           SLACK_MESSAGE: Success
-      - name: Slack Notification Failure
+
+      - name: Notify Slack about failure
         if: failure()
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -53,15 +64,20 @@ jobs:
           MSG_MINIMAL: true
           SLACK_TITLE: '@prenda/spark'
           SLACK_MESSAGE: Failure
-      - run: npm run build:icons
+
+      - name: Build @prenda/spark-icons
+        run: npm run build:icons
         # see https://github.com/JS-DevTools/npm-publish/issues/15
         env:
           INPUT_TOKEN: ''
-      - uses: JS-DevTools/npm-publish@v1
+
+      - name: Publish @prenda/spark-icons
+        uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          package: ./dist/libs/spark-icons-alt/package.json
-      - name: Slack Notification Success
+          package: ./dist/libs/spark-icons/package.json
+
+      - name: Notify Slack about success
         if: success()
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -71,9 +87,10 @@ jobs:
           SLACK_ICON: https://github.com/prenda-school/prenda-spark/raw/main/public/img/spark-logo-multicolor-darker.svg
           SLACK_USERNAME: 'Action: NPM Publish'
           MSG_MINIMAL: true
-          SLACK_TITLE: '@prenda/spark-icons'
+          SLACK_TITLE: '@prenda/spark-icons ${{ env.GITHUB_REF }}'
           SLACK_MESSAGE: Success
-      - name: Slack Notification Failure
+
+      - name: Notify Slack about failure
         if: failure()
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/libs/spark-icons/scripts/create-typings.js
+++ b/libs/spark-icons/scripts/create-typings.js
@@ -7,10 +7,7 @@ import fse from 'fs-extra';
 import glob from 'glob';
 
 const SRC_DIR = path.resolve(__dirname, '../src');
-const TARGET_DIR = path.resolve(
-  __dirname,
-  '../../../dist/libs/spark-icons-alt'
-);
+const TARGET_DIR = path.resolve(__dirname, '../../../dist/libs/spark-icons');
 
 function normalizeFileName(file) {
   return path.parse(file).name;

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.12.0...vNext) (yyyy-mm-dd)
 
+### Features
+
+- Support deeper file imports
+  - example: `import Avatar from '@prenda/spark/Avatar';`
+
 # [v0.12.0](https://github.com/prenda-school/prenda-spark/compare/v0.11.1...v0.12.0) (2021-09-28)
 
 ### Features

--- a/libs/spark/tsconfig.build.json
+++ b/libs/spark/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  // This config is for emitting declarations (.d.ts) only
+  // Actual .ts source files are transpiled via babel
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "../../dist/libs/spark",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/spark/tsconfig.lib.json
+++ b/libs/spark/tsconfig.lib.json
@@ -16,5 +16,11 @@
     "**/*.stories.jsx",
     "**/*.stories.tsx"
   ],
-  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+  "include": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx",
+    "../../scripts/babel.config.js"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prenda-spark",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12401,6 +12401,20 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
       "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
       "dev": true
+    },
+    "babel-plugin-optimize-clsx": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-optimize-clsx/-/babel-plugin-optimize-clsx-2.6.2.tgz",
+      "integrity": "sha512-TxgyjdVb7trTAsg/J5ByqJdbBPTYR8yaWLGQGpSxwygw8IFST5gEc1J9QktCGCHCb+69t04DWg9KOE0y2hN30w==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.6.2",
+        "@babel/template": "^7.6.0",
+        "@babel/types": "^7.6.1",
+        "find-cache-dir": "^3.2.0",
+        "lodash": "^4.17.15",
+        "object-hash": "^2.0.3"
+      }
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.2.2",
@@ -25588,6 +25602,12 @@
           }
         }
       }
+    },
+    "object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.10.3",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,15 @@
     "dep-graph": "nx dep-graph",
     "help": "nx help",
     "prepare": "husky install",
-    "src:icons": "UV_THREADPOOL_SIZE=64 babel-node --config-file ./libs/spark-icons/defaults/babel.config.js libs/spark-icons/scripts/builder.js --output-dir libs/spark-icons/src --svg-dir libs/spark-icons/svg-files",
-    "build:icons": "rimraf ./dist/libs/spark-icons-alt && npm run build:icons:envs && npm run build:icons-typings && npm run build:icons-copy-files",
-    "build:icons:envs": "NODE_ENV=\"production\" BABEL_ENV=\"cjs\" babel --config-file ./libs/spark-icons/defaults/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons-alt && BABEL_ENV=\"esm\" babel --config-file ./libs/spark-icons/defaults/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons-alt/esm",
-    "build:icons-typings": "babel-node --config-file ./libs/spark-icons/defaults/babel.config.js libs/spark-icons/scripts/create-typings.js",
-    "build:icons-copy-files": "node ./libs/spark-icons/scripts/copy-files.js"
+    "src:icons": "UV_THREADPOOL_SIZE=64 babel-node --config-file ./scripts/babel.config.js libs/spark-icons/scripts/builder.js --output-dir libs/spark-icons/src --svg-dir libs/spark-icons/svg-files",
+    "build:icons": "rimraf ./dist/libs/spark-icons && npm run build:icons:envs && npm run build:icons:types && npm run build:icons:copy-files",
+    "build:icons:envs": "NODE_ENV=\"production\" BABEL_ENV=\"cjs\" babel --config-file ./scripts/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons && BABEL_ENV=\"esm\" babel --config-file ./scripts/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark-icons/src --out-dir ./dist/libs/spark-icons/esm",
+    "build:icons:types": "babel-node --config-file ./scripts/babel.config.js libs/spark-icons/scripts/create-typings.js",
+    "build:icons:copy-files": "node ./scripts/copy-files.js ./libs/spark-icons ./dist/libs/spark-icons",
+    "build:components": "rimraf ./dist/libs/spark && npm run build:components:envs && npm run build:components:copy-files && npm run build:components:types",
+    "build:components:envs": "NODE_ENV=\"production\" BABEL_ENV=\"cjs\" babel --config-file ./scripts/babel.config.js --extensions \".js,.ts,.tsx\" ./libs/spark/src --out-dir ./dist/libs/spark && BABEL_ENV=\"esm\" babel --config-file ./scripts/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark/src --out-dir ./dist/libs/spark/esm && BABEL_ENV=\"es\" babel --config-file ./scripts/babel.config.js --extensions \".js,.ts,.tsx\" libs/spark/src --out-dir ./dist/libs/spark/es",
+    "build:components:types": "tsc -p ./libs/spark/tsconfig.build.json",
+    "build:components:copy-files": "node ./scripts/copy-files.js ./libs/spark ./dist/libs/spark"
   },
   "private": true,
   "dependencies": {
@@ -87,6 +91,7 @@
     "@typescript-eslint/parser": "4.19.0",
     "babel-jest": "26.2.2",
     "babel-loader": "8.1.0",
+    "babel-plugin-optimize-clsx": "^2.6.2",
     "chromatic": "^5.9.0",
     "cypress": "^7.7.0",
     "dotenv": "8.2.0",

--- a/scripts/babel.config.js
+++ b/scripts/babel.config.js
@@ -11,9 +11,7 @@ if (process.env.BABEL_ENV === 'es') {
       '@babel/preset-env',
       {
         bugfixes: true,
-        modules: ['esm', 'production-umd'].includes(process.env.BABEL_ENV)
-          ? false
-          : 'commonjs',
+        modules: ['esm'].includes(process.env.BABEL_ENV) ? false : 'commonjs',
       },
     ],
   ];
@@ -27,6 +25,7 @@ module.exports = {
     '@babel/preset-typescript',
   ]),
   plugins: [
+    'babel-plugin-optimize-clsx',
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
     ['@babel/plugin-transform-runtime', { version: '^7.4.4' }],

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -14,7 +14,7 @@ if (!relativeInDir) {
 }
 if (!relativeOutDir) {
   console.error(
-    'Forgot to supply first positional argument after filename: "out-dir'
+    'Forgot to supply second positional argument after filename: "out-dir'
   );
   process.exit(1);
 }

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -3,9 +3,25 @@ const path = require('path');
 const fse = require('fs-extra');
 const glob = require('glob');
 
+const relativeInDir = process.argv[2];
+const relativeOutDir = process.argv[3];
+
+if (!relativeInDir) {
+  console.error(
+    'Forgot to supply first positional argument after filename: "in-dir'
+  );
+  process.exit(1);
+}
+if (!relativeOutDir) {
+  console.error(
+    'Forgot to supply first positional argument after filename: "out-dir'
+  );
+  process.exit(1);
+}
+
 const packagePath = process.cwd();
-const buildPath = path.join(packagePath, './dist/libs/spark-icons-alt');
-const srcPath = path.join(packagePath, './libs/spark-icons/src');
+const buildPath = path.join(packagePath, relativeOutDir);
+const srcPath = path.join(packagePath, relativeInDir, './src');
 
 async function includeFileInBuild(file) {
   const sourcePath = path.resolve(packagePath, file);
@@ -58,7 +74,9 @@ async function typescriptCopy({ from, to }) {
     return [];
   }
 
-  const files = glob.sync('**/*.d.ts', { cwd: from });
+  const files = glob.sync(path.resolve(relativeInDir, '**/*.d.ts'), {
+    cwd: from,
+  });
   const cmds = files.map((file) =>
     fse.copy(path.resolve(from, file), path.resolve(to, file))
   );
@@ -67,7 +85,7 @@ async function typescriptCopy({ from, to }) {
 
 async function createPackageFile() {
   const packageData = await fse.readFile(
-    path.resolve(packagePath, './libs/spark-icons/package.json'),
+    path.resolve(packagePath, relativeInDir, './package.json'),
     'utf8'
   );
   const {
@@ -102,9 +120,9 @@ async function run() {
 
     await Promise.all(
       [
-        './libs/spark-icons/README.md',
-        // './libs/spark-icons/CHANGELOG.md',
-        // './libs/spark-icons/LICENSE',
+        path.resolve(relativeInDir, './README.md'),
+        // path.resolve(relativeInDir, './CHANGELOG.md'),
+        // path.resolve(relativeInDir, './LICENSE'),
       ].map((file) => includeFileInBuild(file))
     );
 


### PR DESCRIPTION
Closes #213 and #242 

- Hoist custom `babel.config.js` and `copy-files.js` to top-level `scripts/` directory. Generalize them slightly to fit both use-cases.
  - dist files are now written to the libraries exact name, not with `-alt` appended.
- `npm-publish` workflow
  - Add descriptive names to each step
  - Add version number (stored in GITHUB_REF env var when action is triggered by `release`)

I've run both build processes locally and they work as expected. I also tried importing a component into a story from the `dist/` directory using a deep import (ex: `import Avatar from '../../../dist/libs/spark/Avatar';` and it both rendered correctly and had correct type and props hinting/annotations.