### PR TITLE
fix: styles using global classes failing

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.13.1...vNext) (yyyy-mm-dd)
 
+### Fixes
+
+- Styles no longer rely on fully-deterministic global Mui class names.
+  - Example: When two `ThemeProvider`'s are used, `'MuiSvgIcon-root'` would change to `'MuiSvgIcon-root-10'`. To address this, selectors like `'& .MuiSvgIcon-root'` were changed to `'& [class*=MuiSvgIcon-root]'`.
+  - Affected components: **Avatar**, **Button**, **Checkbox**, **FormHelperText**, **FormLabel**, **IconButton**, **InputAdornment**, **InputBase**, **ListItemIcon**, **Menu**, **NavBarButton**, **Pagination**, **Radio**, **Switch**, **Tag**.
+
 # [v0.13.1](https://github.com/prenda-school/prenda-spark/compare/v0.13.0...v0.13.1) (2021-10-01)
 
 ### Fixes

--- a/libs/spark/src/Avatar.tsx
+++ b/libs/spark/src/Avatar.tsx
@@ -45,7 +45,7 @@ export const MuiAvatarStyleOverrides = ({ palette }: Theme) => ({
   colorDefault: {
     backgroundColor: palette.common.white,
     color: palette.text.onLight,
-    '& > .MuiSvgIcon-root': {
+    '& [class*=MuiSvgIcon-root]': {
       color: palette.text.onLightLowContrast,
     },
   },
@@ -57,7 +57,7 @@ const useCustomStyles = makeStyles(
       ...theme.typography['heading-lg'],
       width: 80,
       height: 80,
-      '& > .MuiSvgIcon-root': {
+      '& [class*=MuiSvgIcon-root]': {
         fontSize: theme.typography.pxToRem(40),
       },
     },
@@ -65,7 +65,7 @@ const useCustomStyles = makeStyles(
       ...theme.typography['heading-md'],
       width: 56,
       height: 56,
-      '& > .MuiSvgIcon-root': {
+      '& [class*=MuiSvgIcon-root]': {
         fontSize: theme.typography.pxToRem(28),
       },
     },
@@ -74,7 +74,7 @@ const useCustomStyles = makeStyles(
       fontWeight: 700,
       width: 32,
       height: 32,
-      '& > .MuiSvgIcon-root': {
+      '& [class*=MuiSvgIcon-root]': {
         fontSize: theme.typography.pxToRem(16),
       },
     },
@@ -84,7 +84,7 @@ const useCustomStyles = makeStyles(
       fontSize: theme.typography.pxToRem(8),
       lineHeight: 1.5,
       fontWeight: 700,
-      '& > .MuiSvgIcon-root': {
+      '& [class*=MuiSvgIcon-root]': {
         fontSize: theme.typography.pxToRem(12),
       },
     },

--- a/libs/spark/src/Button.ts
+++ b/libs/spark/src/Button.ts
@@ -129,11 +129,6 @@ export const MuiButtonStyleOverrides = ({
     marginRight: '8px',
     marginLeft: 0,
     color: 'inherit',
-    '& > .MuiSvgIcon-root': {
-      color: 'inherit',
-      fontSize: 'inherit',
-      lineHeight: 'inherit',
-    },
     // artificially increase specificity to win battle with default
     '&& > :first-child': {
       fontSize: 'inherit',
@@ -148,11 +143,6 @@ export const MuiButtonStyleOverrides = ({
     marginLeft: '8px',
     marginRight: 0,
     color: 'inherit',
-    '& > .MuiSvgIcon-root': {
-      color: 'inherit',
-      fontSize: 'inherit',
-      lineHeight: 'inherit',
-    },
     // artificially increase specificity to win battle with default
     '&& > :first-child': {
       fontSize: 'inherit',

--- a/libs/spark/src/Checkbox.tsx
+++ b/libs/spark/src/Checkbox.tsx
@@ -20,7 +20,7 @@ const SparkCheckboxIconRoot = styled('span')(
       // Adjust for irregular svg size of checkbox icons
       height: 22,
       width: 22,
-      '& .MuiSvgIcon-root': {
+      '& [class*=MuiSvgIcon-root]': {
         width: 22,
         height: 22,
       },
@@ -29,16 +29,14 @@ const SparkCheckboxIconRoot = styled('span')(
       },
       '&:focus, input:focus ~ &': {
         boxShadow: `0 0 0 4px ${palette.blue[1]}`,
-        '&:not(.SparkCheckboxIcon-checked):not(.SparkCheckboxIcon-indeterminate) .MuiSvgIcon-root': {
-          '&.SparkCheckboxIcon-box': {
-            color: palette.blue[3],
-            backgroundColor: palette.common.white,
-          },
+        '&:not(.SparkCheckboxIcon-checked):not(.SparkCheckboxIcon-indeterminate) .SparkCheckboxIcon-box': {
+          color: palette.blue[3],
+          backgroundColor: palette.common.white,
         },
       },
     },
     '&.SparkCheckboxIcon-checked': {
-      '& .MuiSvgIcon-root.SparkCheckboxIcon-check': {
+      '& .SparkCheckboxIcon-check': {
         transform: 'scale(1)',
         color: palette.common.white,
         transition: transitions.create('transform', {
@@ -46,12 +44,12 @@ const SparkCheckboxIconRoot = styled('span')(
           duration: transitions.duration.shortest,
         }),
       },
-      '& .MuiSvgIcon-root.SparkCheckboxIcon-box': {
+      '& .SparkCheckboxIcon-box': {
         backgroundColor: palette.blue[3],
       },
     },
     '&.SparkCheckboxIcon-indeterminate': {
-      '& .MuiSvgIcon-root.SparkCheckboxIcon-dash': {
+      '& .SparkCheckboxIcon-dash': {
         transform: 'scale(1)',
         color: palette.common.white,
         transition: transitions.create('transform', {
@@ -59,16 +57,16 @@ const SparkCheckboxIconRoot = styled('span')(
           duration: transitions.duration.shortest,
         }),
       },
-      '& .MuiSvgIcon-root.SparkCheckboxIcon-box': {
+      '& .SparkCheckboxIcon-box': {
         backgroundColor: palette.blue[3],
       },
     },
-    '& .MuiSvgIcon-root.SparkCheckboxIcon-box': {
+    '& .SparkCheckboxIcon-box': {
       borderRadius: 2,
       // from Mui, scale applied to prevent dot misalignment in Safari
       transform: 'scale(1)',
     },
-    '& .MuiSvgIcon-root.SparkCheckboxIcon-check, & .MuiSvgIcon-root.SparkCheckboxIcon-dash': {
+    '& .SparkCheckboxIcon-check, & .SparkCheckboxIcon-dash': {
       color: palette.blue[1],
       backgroundColor: 'transparent',
       position: 'absolute' as const,
@@ -151,14 +149,14 @@ export const MuiCheckboxStyleOverrides = ({ palette }: Theme) => ({
       color: palette.blue[3],
     },
     '&$disabled': {
-      '& > .MuiIconButton-label > .SparkCheckboxIcon-root': {
-        '& > .MuiSvgIcon-root': {
+      '& .SparkCheckboxIcon-root': {
+        '& [class*=MuiSvgIcon-root]': {
           color: palette.grey.dark,
         },
-        '& > .SparkCheckboxIcon-box': {
+        '& .SparkCheckboxIcon-box': {
           backgroundColor: palette.grey.medium,
         },
-        '& > .SparkCheckboxIcon-check, .SparkCheckboxIcon-dash': {
+        '& .SparkCheckboxIcon-check, & .SparkCheckboxIcon-dash': {
           color: palette.grey[400],
         },
       },

--- a/libs/spark/src/FormHelperText.ts
+++ b/libs/spark/src/FormHelperText.ts
@@ -21,10 +21,10 @@ export const MuiFormHelperTextStyleOverrides = ({
     '&$disabled': {
       color: palette.grey.dark,
     },
-    '.MuiFormGroup-root ~ &': {
+    '[class*=MuiFormGroup-root] ~ &': {
       marginTop: 3,
     },
-    '.MuiTextField-root > &$error': {
+    '[class*=MuiTextField-root] > &$error': {
       color: palette.text.onLightLowContrast,
     },
   },

--- a/libs/spark/src/FormLabel.ts
+++ b/libs/spark/src/FormLabel.ts
@@ -22,7 +22,8 @@ export const MuiFormLabelStyleOverrides = ({
     '&$focused': {
       color: palette.blue[3],
     },
-    '&$error.MuiInputLabel-root': {
+    // artificially increase specificity to win battle with spark default
+    '&&$error': {
       color: 'inherit',
     },
   },

--- a/libs/spark/src/FormLabel.ts
+++ b/libs/spark/src/FormLabel.ts
@@ -22,8 +22,8 @@ export const MuiFormLabelStyleOverrides = ({
     '&$focused': {
       color: palette.blue[3],
     },
-    // artificially increase specificity to win battle with spark default
-    '&&$error': {
+    // ONLY override for Input (not in a Checkbox / Radio group)
+    '&$error[class*=MuiInputLabel-root]': {
       color: 'inherit',
     },
   },

--- a/libs/spark/src/IconButton.tsx
+++ b/libs/spark/src/IconButton.tsx
@@ -52,7 +52,7 @@ type CustomClassKey =
   | 'labelSizeMedium';
 
 const useCustomStyles = makeStyles(
-  ({ palette }) => ({
+  ({ palette, typography }) => ({
     root: {
       borderRadius: '50%',
       borderWidth: 2,
@@ -66,17 +66,12 @@ const useCustomStyles = makeStyles(
     },
     label: {
       color: 'inherit',
-      fontSize: '1.5rem', // 24px
-      lineHeight: '1.5rem', // 24px
-      '& > .MuiSvgIcon-root': {
-        color: 'inherit',
+      // :TODO: delete when SvgIcon implements 'medium' class and removes default `fontSize: 1.5rem`
+      '& [class*=MuiSvgIcon-root]': {
         fontSize: 'inherit',
-        lineHeight: 'inherit',
       },
     },
-    disabled: {
-      // opacity: '50%',
-    },
+    disabled: {},
     contained: {
       borderColor: palette.blue[3],
       backgroundColor: palette.blue[3],
@@ -135,10 +130,13 @@ const useCustomStyles = makeStyles(
     sizeMedium: {
       padding: 4, // plus 2px border width for 6px
     },
-    labelSizeLarge: {},
+    labelSizeLarge: {
+      fontSize: typography.pxToRem(24),
+      lineHeight: typography.pxToRem(24),
+    },
     labelSizeMedium: {
-      fontSize: '1.25rem', // 20px
-      lineHeight: '1.25rem', // 20px
+      fontSize: typography.pxToRem(20),
+      lineHeight: typography.pxToRem(20),
     },
   }),
   { name: 'MuiSparkIconButton' }

--- a/libs/spark/src/InputAdornment.ts
+++ b/libs/spark/src/InputAdornment.ts
@@ -7,7 +7,7 @@ export type { InputAdornmentProps };
 
 export const MuiInputAdornmentStylesOverrides = {
   root: {
-    '.MuiInputBase-multiline > &': {
+    '[class*=MuiInputBase-multiline] > &': {
       alignSelf: 'flex-start',
       // half of typical 24px icon height + 10px input top margin
       marginTop: 22,

--- a/libs/spark/src/InputBase.tsx
+++ b/libs/spark/src/InputBase.tsx
@@ -31,7 +31,7 @@ export const MuiInputBaseStyleOverrides = ({
       boxShadow: `0 0 0 4px ${palette.blue[1]}`,
       backgroundColor: palette.common.white,
     },
-    '&.Spark-success, .MuiTextField-root.Spark-success > &': {
+    '&.Spark-success, [class*=MuiTextField-root].Spark-success > &': {
       borderColor: palette.green[3],
       boxShadow: `0 0 0 4px ${palette.green[1]}`,
     },

--- a/libs/spark/src/ListItemIcon.ts
+++ b/libs/spark/src/ListItemIcon.ts
@@ -10,7 +10,7 @@ export const MuiListItemIconStyleOverrides = ({ palette }: Theme) => ({
     color: palette.text.onLightLowContrast,
     minWidth: 'unset',
     marginRight: 8,
-    '& .MuiCheckbox-root': {
+    '& [class*=MuiCheckbox-root]': {
       padding: 1,
     },
     '.Mui-selected > &': {

--- a/libs/spark/src/Menu.ts
+++ b/libs/spark/src/Menu.ts
@@ -20,7 +20,7 @@ export const MuiMenuStyleOverrides = ({ palette }: Theme) => ({
     // have the desired affect, but other combos do not work.
     // TODO: open issue and submit PR for a new prop that gets factored into
     // the absolute positioning of the Paper, like `additionalContentOffset`.
-    '&.MuiSparkMenu-offsetTop': {
+    '&[class*=MuiSparkMenu-offsetTop]': {
       marginTop: 8,
     },
   },

--- a/libs/spark/src/NavBarButton.tsx
+++ b/libs/spark/src/NavBarButton.tsx
@@ -27,7 +27,7 @@ const NavBarButton = withStyles((theme) => ({
       border: `2px solid ${theme.palette.grey.light}`,
       backgroundColor: theme.palette.grey.light,
       color: theme.palette.text.onLight,
-      '& .MuiSvgIcon-root > *[fill="#F0F1F2"]': {
+      '& *[fill="#F0F1F2"]': {
         fill: theme.palette.blue[3],
         fillOpacity: '0.24',
       },
@@ -51,13 +51,14 @@ const NavBarButton = withStyles((theme) => ({
     marginRight: 0,
   },
   iconSizeLarge: {
-    // artificially increase specificity to win battle with default
+    // artificially increase specificity to win battle with mui default
     '&& > :first-child': {
       fontSize: '2rem',
     },
   },
   disabled: {
-    '&.MuiButton-contained': {
+    // artificially increase specificity to win battle with spark default
+    '&&': {
       opacity: '100%',
       color: theme.palette.grey.dark,
       backgroundColor: 'transparent',

--- a/libs/spark/src/Pagination.ts
+++ b/libs/spark/src/Pagination.ts
@@ -12,20 +12,20 @@ export const MuiPaginationStyleOverrides = {
       borderTopLeftRadius: '8px',
       borderBottomLeftRadius: '8px',
     },
-    '& > li:last-child > .MuiPaginationItem-root': {
+    '& > li:last-child > [class*=MuiPaginationItem-root]': {
       borderTopRightRadius: 8,
       borderBottomRightRadius: 8,
     },
-    '& > li:not(:last-child) > .MuiPaginationItem-root': {
+    '& > li:not(:last-child) > [class*=MuiPaginationItem-root]': {
       marginRight: -1,
     },
-    '& > li:not(:first-child) > .MuiPaginationItem-root': {
+    '& > li:not(:first-child) > [class*=MuiPaginationItem-root]': {
       marginLeft: -1,
     },
-    '& > li > .MuiPaginationItem-root.Mui-selected': {
+    '& > li > [class*=MuiPaginationItem-root].Mui-selected': {
       zIndex: 2,
     },
-    '& > li > .MuiPaginationItem-root:hover, .MuiPaginationItem-root:focus, button.Mui-focusVisible': {
+    '& > li > [class*=MuiPaginationItem-root]:hover, [class*=MuiPaginationItem-root]:focus, button.Mui-focusVisible': {
       zIndex: 1,
     },
   },

--- a/libs/spark/src/Radio.tsx
+++ b/libs/spark/src/Radio.tsx
@@ -20,7 +20,7 @@ const SparkRadioIconRoot = styled('span')(
       // Adjust for irregular svg size of radio unchecked button
       height: '26px',
       width: '26px',
-      '& .MuiSvgIcon-root': {
+      '& [class*=MuiSvgIcon-root]': {
         height: '26px',
         width: '26px',
         backgroundColor: palette.common.white,
@@ -33,7 +33,7 @@ const SparkRadioIconRoot = styled('span')(
       },
       '&:focus, input:focus ~ &': {
         boxShadow: `0 0 0 4px ${palette.blue[1]}`,
-        '&:not(.SparkRadioIcon-checked) .MuiSvgIcon-root.SparkRadioIcon-dot': {
+        '&:not(.SparkRadioIcon-checked) .SparkRadioIcon-dot': {
           color: palette.blue[1],
         },
         '& .SparkRadioIcon-checked .SparkRadioIcon-dot': {
@@ -127,14 +127,14 @@ export const MuiRadioStyleOverrides = ({ palette }: Theme) => ({
       color: palette.blue[3],
     },
     '&$disabled': {
-      '& > .MuiIconButton-label > .SparkRadioIcon-root': {
-        '& > .MuiSvgIcon-root': {
+      '& .SparkRadioIcon-root': {
+        '& [class*=MuiSvgIcon-root]': {
           color: palette.grey.dark,
         },
-        '& > .SparkRadioIcon-circle': {
+        '& .SparkRadioIcon-circle': {
           backgroundColor: palette.grey.medium,
         },
-        '& > .SparkRadioIcon-dot': {
+        '& .SparkRadioIcon-dot': {
           color: palette.grey[400],
         },
       },

--- a/libs/spark/src/Switch.tsx
+++ b/libs/spark/src/Switch.tsx
@@ -43,9 +43,9 @@ export const MuiSwitchStyleOverrides = ({ palette }: Theme) => ({
     height: 32 + 8,
     width: 56 + 8,
     padding: 4,
-    '& + .MuiFormControlLabel-label': {
+    '& + [class*=MuiFormControlLabel-label]': {
       marginLeft: 4,
-      '.MuiFormControlLabel-labelPlacementStart &': {
+      '[class*=MuiFormControlLabel-labelPlacementStart] &': {
         marginLeft: 0,
         marginRight: 4,
       },

--- a/libs/spark/src/Tag.tsx
+++ b/libs/spark/src/Tag.tsx
@@ -270,37 +270,37 @@ const useCustomStyles = makeStyles(
     },
     deleteIconColorRed: {
       color: theme.palette.red[5],
-      '&:hover, .MuiChip-root:focus > &': {
+      '&:hover, [class*=MuiChip-root]:focus > &': {
         backgroundColor: theme.palette.red[5],
       },
     },
     deleteIconColorOrange: {
       color: theme.palette.orange[5],
-      '&:hover, .MuiChip-root:focus > &': {
+      '&:hover, [class*=MuiChip-root]:focus > &': {
         backgroundColor: theme.palette.orange[5],
       },
     },
     deleteIconColorYellow: {
       color: theme.palette.yellow[5],
-      '&:hover, .MuiChip-root:focus > &': {
+      '&:hover, [class*=MuiChip-root]:focus > &': {
         backgroundColor: theme.palette.yellow[5],
       },
     },
     deleteIconColorGreen: {
       color: theme.palette.green[5],
-      '&:hover, .MuiChip-root:focus > &': {
+      '&:hover, [class*=MuiChip-root]:focus > &': {
         backgroundColor: theme.palette.green[5],
       },
     },
     deleteIconColorBlue: {
       color: theme.palette.blue[5],
-      '&:hover, .MuiChip-root:focus > &': {
+      '&:hover, [class*=MuiChip-root]:focus > &': {
         backgroundColor: theme.palette.blue[5],
       },
     },
     deleteIconColorPurple: {
       color: theme.palette.purple[5],
-      '&:hover, .MuiChip-root:focus > &': {
+      '&:hover, [class*=MuiChip-root]:focus > &': {
         backgroundColor: theme.palette.purple[5],
       },
     },


### PR DESCRIPTION
Close #275 

Where possible, these global classes were eliminated. Where elimination wasn't possible, they were changed to select "occurrence" _within_ the class attribute value string (see https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#syntax).