### PR TITLE
feat(Unstable_Link): add variant prop

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -7,8 +7,11 @@
 _This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
 
 - **Unstable_AvatarButton**
-  - Props API Changes:
+  - Props API changes:
     - `size`: added; values `'large' | 'medium'` where `'large'` is default.
+- **Unstable_Link**
+  - Props API changes:
+    - `variant`: added; values `'standard' | 'alias'` where `'standard'` is default.
 
 ## [v1.0.0-alpha.10](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.9...v1.0.0-alpha.10) (2022-06-22)
 

--- a/libs/spark/src/Unstable_Link/Unstable_Link.stories.tsx
+++ b/libs/spark/src/Unstable_Link/Unstable_Link.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
-import { Unstable_Link } from '..';
+import { theme, Unstable_Link } from '..';
 import { containFocusIndicator } from '../../stories';
 
 export const _retyped = Unstable_Link as typeof Unstable_Link;
@@ -85,3 +85,13 @@ const ColorInheritTemplate = (args) => (
 export const ColorInherit: Story = ColorInheritTemplate.bind({});
 ColorInherit.args = { color: 'inherit' };
 ColorInherit.storyName = 'color=inherit';
+
+const VariantAliasTemplate = (args) => (
+  <span style={{ ...theme.unstable_typography.label }}>
+    <Unstable_Link {...args}>Text</Unstable_Link>
+  </span>
+);
+
+export const VariantAlias: Story = VariantAliasTemplate.bind({});
+VariantAlias.args = { variant: 'alias' };
+VariantAlias.storyName = 'variant=alias';

--- a/libs/spark/src/Unstable_Link/Unstable_Link.tsx
+++ b/libs/spark/src/Unstable_Link/Unstable_Link.tsx
@@ -21,7 +21,11 @@ export interface Unstable_LinkTypeMap<
       /**
        * The color of the link.
        */
-      color?: 'default' | 'inherit';
+      color?: 'standard' | 'inherit';
+      /**
+       * The variant of the link.
+       */
+      variant?: 'standard' | 'alias';
     };
   defaultComponent: D;
   classKey: Unstable_LinkClassKey;
@@ -39,7 +43,6 @@ const useStyles = makeStyles<Unstable_LinkClassKey>(
   (theme) => ({
     /* Styles applied to the root element. */
     root: (props: Unstable_LinkProps) => ({
-      ...theme.unstable_typography.body,
       textDecoration: 'underline',
       '&.Mui-focusVisible, &:focus-visible': {
         boxShadow: `0 0 2px 4px ${theme.unstable_palette.teal[200]}`,
@@ -49,7 +52,7 @@ const useStyles = makeStyles<Unstable_LinkClassKey>(
         textDecoration: 'none',
       }),
       /* color */
-      ...((!props.color || props.color === 'default') && {
+      ...(props.color === 'standard' && {
         color: theme.unstable_palette.blue['600'],
         '&:hover': {
           color: theme.unstable_palette.blue['500'],
@@ -62,6 +65,10 @@ const useStyles = makeStyles<Unstable_LinkClassKey>(
         },
       }),
       ...(props.color === 'inherit' && { color: 'inherit' }),
+      /* variant */
+      ...(props.variant === 'standard' && {
+        ...theme.unstable_typography.body,
+      }),
       // reset browser default
       '&:focus': {
         outline: 'none',
@@ -75,12 +82,13 @@ const Unstable_Link: OverridableComponent<Unstable_LinkTypeMap> = forwardRef(
   function Unstable_Link(props, ref) {
     const {
       classes: classesProp,
-      color = 'default',
+      color = 'standard',
+      variant = 'standard',
       standalone,
       ...other
     } = props;
 
-    const classes = useStyles({ color, standalone });
+    const classes = useStyles({ color, variant, standalone });
 
     return (
       <MuiLink


### PR DESCRIPTION
- current design given to default variant, 'standard'
- variant 'alias' means it will take on the typographical properties already assigned to it, but maintain color properties.

This will be important for ensuring a design can keep its typographical composure but function in color / underline like our Link and not a simple anchor tag.